### PR TITLE
Migrate from master and slave terminology

### DIFF
--- a/apply_issue.py
+++ b/apply_issue.py
@@ -273,7 +273,7 @@ def main():
       parser.error('Couldn\'t determine the scm')
 
     # TODO(maruel): HACK, remove me.
-    # When run a build slave, make sure buildbot knows that the checkout was
+    # When run a build subordinate, make sure buildbot knows that the checkout was
     # modified.
     if options.root_dir == 'src' and getpass.getuser() == 'chrome-bot':
       # See sourcedirIsPatched() in:

--- a/buildbucket.py
+++ b/buildbucket.py
@@ -9,7 +9,7 @@ Usage:
   $ depot-tools-auth login https://cr-buildbucket.appspot.com
   $ buildbucket.py \
     put \
-    --bucket master.tryserver.chromium.linux \
+    --bucket main.tryserver.chromium.linux \
     --builder my-builder \
 
   Puts a build into buildbucket for my-builder on tryserver.chromium.linux.
@@ -52,8 +52,8 @@ def main(argv):
     '-b',
     '--bucket',
     help=(
-      'The bucket to schedule the build on. Typically the master name, e.g.'
-      ' master.tryserver.chromium.linux.'
+      'The bucket to schedule the build on. Typically the main name, e.g.'
+      ' main.tryserver.chromium.linux.'
     ),
     required=True,
   )

--- a/checkout.py
+++ b/checkout.py
@@ -571,8 +571,8 @@ class GitCheckout(CheckoutBase):
     self.working_branch = 'working_branch'
     # There is no reason to not hardcode origin.
     self.remote = 'origin'
-    # There is no reason to not hardcode master.
-    self.master_branch = 'master'
+    # There is no reason to not hardcode main.
+    self.main_branch = 'main'
 
   def prepare(self, revision):
     """Resets the git repository in a clean state.
@@ -608,9 +608,9 @@ class GitCheckout(CheckoutBase):
       self._check_call_git(['checkout', '--force', '--quiet', revision])
     else:
       branches, active = self._branches()
-      if active != self.master_branch:
+      if active != self.main_branch:
         self._check_call_git(
-            ['checkout', '--force', '--quiet', self.master_branch])
+            ['checkout', '--force', '--quiet', self.main_branch])
       self._sync_remote_branch()
 
       if self.working_branch in branches:
@@ -619,8 +619,8 @@ class GitCheckout(CheckoutBase):
 
   def _sync_remote_branch(self):
     """Syncs the remote branch."""
-    # We do a 'git pull origin master:refs/remotes/origin/master' instead of
-    # 'git pull origin master' because from the manpage for git-pull:
+    # We do a 'git pull origin main:refs/remotes/origin/main' instead of
+    # 'git pull origin main' because from the manpage for git-pull:
     #   A parameter <ref> without a colon is equivalent to <ref>: when
     #   pulling/fetching, so it merges <ref> into the current branch without
     #   storing the remote branch anywhere locally.

--- a/commit_queue.py
+++ b/commit_queue.py
@@ -102,18 +102,18 @@ def set_commit(obj, issue, flag):
   _apply_on_issue(_set_commit, obj, issue)
 
 
-def get_master_builder_map(
+def get_main_builder_map(
       config_path, include_experimental=True, include_triggered=True):
-  """Returns a map of master -> [builders] from cq config."""
+  """Returns a map of main -> [builders] from cq config."""
   with open(config_path) as config_file:
     cq_config = config_file.read()
 
   config = cq_pb2.Config()
   text_format.Merge(cq_config, config)
-  masters = {}
+  mains = {}
   if config.HasField('verifiers') and config.verifiers.HasField('try_job'):
     for bucket in config.verifiers.try_job.buckets:
-      masters.setdefault(bucket.name, [])
+      mains.setdefault(bucket.name, [])
       for builder in bucket.builders:
         if (not include_experimental and
             builder.HasField('experiment_percentage')):
@@ -121,8 +121,8 @@ def get_master_builder_map(
         if (not include_triggered and
             builder.HasField('triggered_by')):
           continue
-        masters[bucket.name].append(builder.name)
-  return masters
+        mains[bucket.name].append(builder.name)
+  return mains
 
 
 @need_issue
@@ -155,11 +155,11 @@ def CMDbuilders(parser, args):
 
   The output is a dictionary in the following format:
     {
-      'master_name': [
+      'main_name': [
         'builder_name',
         'another_builder'
       ],
-      'another_master': [
+      'another_main': [
         'third_builder'
       ]
     }
@@ -176,7 +176,7 @@ def CMDbuilders(parser, args):
   if len(args) != 1:
     parser.error('Expected a single path to CQ config. Got: %s' %
                  ' '.join(args))
-  print json.dumps(get_master_builder_map(
+  print json.dumps(get_main_builder_map(
       args[0],
       include_experimental=options.include_experimental,
       include_triggered=options.include_triggered))

--- a/external_bin/gsutil/gsutil_4.15/gsutil/gslib/addlhelp/naming.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/gslib/addlhelp/naming.py
@@ -94,8 +94,8 @@ _DETAILED_HELP_TEXT = ("""
   user who creates the bucket, so the user who creates the bucket must
   also be verified as an owner or manager of the domain.
 
-  To verify as the owner or manager of a domain, use the Google Webmaster
-  Tools verification process. The Webmaster Tools verification process
+  To verify as the owner or manager of a domain, use the Google Webmain
+  Tools verification process. The Webmain Tools verification process
   provides three methods for verifying an owner or manager of a domain:
 
   1. Adding a special Meta tag to a site's homepage.

--- a/external_bin/gsutil/gsutil_4.15/gsutil/gslib/commands/notification.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/gslib/commands/notification.py
@@ -126,7 +126,7 @@ which is not authorized for your project. Please ensure that you are using
 Service Account authentication and that the Service Account's project is
 authorized for the application URL. Notification endpoint URLs must also be
 whitelisted in your Cloud Console project. To do that, the domain must also be
-verified using Google Webmaster Tools. For instructions, please see:
+verified using Google Webmain Tools. For instructions, please see:
 
   https://developers.google.com/storage/docs/object-change-notification#_Authorization
 """

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/apitools/apitools/base/py/batch.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/apitools/apitools/base/py/batch.py
@@ -159,7 +159,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/apitools/run_pylint.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/apitools/run_pylint.py
@@ -103,9 +103,9 @@ def get_files_for_linting(allow_limited=True):
     uses a specific commit or branch (a so-called diff base) to compare
     against for changed files. (This requires ``allow_limited=True``.)
 
-    To speed up linting on Travis pull requests against master, we manually
-    set the diff base to origin/master. We don't do this on non-pull requests
-    since origin/master will be equivalent to the currently checked out code.
+    To speed up linting on Travis pull requests against main, we manually
+    set the diff base to origin/main. We don't do this on non-pull requests
+    since origin/main will be equivalent to the currently checked out code.
     One could potentially use ${TRAVIS_COMMIT_RANGE} to find a diff base but
     this value is not dependable.
 
@@ -122,11 +122,11 @@ def get_files_for_linting(allow_limited=True):
               linted.
     """
     diff_base = None
-    if (os.getenv('TRAVIS_BRANCH') == 'master' and
+    if (os.getenv('TRAVIS_BRANCH') == 'main' and
             os.getenv('TRAVIS_PULL_REQUEST') != 'false'):
-        # In the case of a pull request into master, we want to
-        # diff against HEAD in master.
-        diff_base = 'origin/master'
+        # In the case of a pull request into main, we want to
+        # diff against HEAD in main.
+        diff_base = 'origin/main'
     elif os.getenv('TRAVIS') is None:
         # Only allow specified remote and branch in local dev.
         remote = os.getenv('GCLOUD_REMOTE_FOR_LINT')

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/emr/connection.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/emr/connection.py
@@ -398,8 +398,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -426,11 +426,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -461,7 +461,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -515,15 +515,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -710,15 +710,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/emr/step.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/kms/layer1.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/opsworks/layer1.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/pyami/bootstrap.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/rds/__init__.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/rds/__init__.py
@@ -139,8 +139,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -169,8 +169,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -223,8 +223,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -241,8 +241,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -399,8 +399,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -424,8 +424,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -563,7 +563,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -594,8 +594,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -681,8 +681,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/rds/dbinstance.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/rds/dbsnapshot.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/rds2/layer1.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/rds2/layer1.py
@@ -319,8 +319,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -415,9 +415,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -450,8 +450,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -534,7 +534,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -653,8 +653,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2478,7 +2478,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2606,14 +2606,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2624,7 +2624,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2658,7 +2658,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2810,8 +2810,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/redshift/layer1.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/integration/rds2/test_connection.py
@@ -44,8 +44,8 @@ class TestRDS2Connection(unittest.TestCase):
             allocated_storage=5,
             db_instance_class='db.t1.micro',
             engine='postgres',
-            master_username='bototestuser',
-            master_user_password='testtestt3st',
+            main_username='bototestuser',
+            main_user_password='testtestt3st',
             # Try to limit the impact & test options.
             multi_az=False,
             backup_retention_period=0

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/integration/redshift/test_layer1.py
@@ -36,8 +36,8 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         self.api = RedshiftConnection()
         self.cluster_prefix = 'boto-redshift-cluster-%s'
         self.node_type = 'dw.hs1.xlarge'
-        self.master_username = 'mrtest'
-        self.master_password = 'P4ssword'
+        self.main_username = 'mrtest'
+        self.main_password = 'P4ssword'
         self.db_name = 'simon'
         # Redshift was taking ~20 minutes to bring clusters up in testing.
         self.wait_time = 60 * 20
@@ -50,7 +50,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 
@@ -71,7 +71,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/emr/test_connection.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/emr/test_connection.py
@@ -182,7 +182,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
             <EndDateTime>2014-01-24T02:19:46Z</EndDateTime>
           </Timeline>
         </Status>
-        <Name>Master instance group</Name>
+        <Name>Main instance group</Name>
         <RequestedInstanceCount>1</RequestedInstanceCount>
         <RunningInstanceCount>0</RunningInstanceCount>
         <InstanceGroupType>MASTER</InstanceGroupType>
@@ -238,7 +238,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         self.assertEqual(response.instancegroups[0].instancegrouptype, "MASTER")
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
-        self.assertEqual(response.instancegroups[0].name, "Master instance group")
+        self.assertEqual(response.instancegroups[0].name, "Main instance group")
         self.assertEqual(response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
         self.assertTrue(isinstance(response.instancegroups[0].status, ClusterStatus))
@@ -566,7 +566,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         </member>
       </Applications>
       <TerminationProtected>false</TerminationProtected>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+      <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
       <NormalizedInstanceHours>10</NormalizedInstanceHours>
       <ServiceRole>my-service-role</ServiceRole>
     </Cluster>
@@ -598,7 +598,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         self.assertEqual(response.status.state, 'TERMINATED')
         self.assertEqual(response.applications[0].name, 'hadoop')
         self.assertEqual(response.applications[0].version, '1.0.3')
-        self.assertEqual(response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(response.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(response.normalizedinstancehours, '10')
         self.assertEqual(response.servicerole, 'my-service-role')
 
@@ -836,7 +836,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
           <Placement>
             <AvailabilityZone>us-west-1c</AvailabilityZone>
           </Placement>
-          <MasterInstanceType>m1.large</MasterInstanceType>
+          <MainInstanceType>m1.large</MainInstanceType>
           <Ec2KeyName>my_key</Ec2KeyName>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
           <InstanceGroups>
@@ -853,7 +853,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Market>ON_DEMAND</Market>
               <InstanceGroupId>ig-aaaaaa</InstanceGroupId>
               <InstanceRole>MASTER</InstanceRole>
-              <Name>Master instance group</Name>
+              <Name>Main instance group</Name>
             </member>
             <member>
               <CreationDateTime>2014-01-24T01:21:21Z</CreationDateTime>
@@ -871,11 +871,11 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Name>Core instance group</Name>
             </member>
           </InstanceGroups>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-aaaaaa</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-aaaaaa</MainInstanceId>
           <HadoopVersion>1.0.3</HadoopVersion>
           <NormalizedInstanceHours>12</NormalizedInstanceHours>
-          <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+          <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
           <InstanceCount>3</InstanceCount>
           <TerminationProtected>false</TerminationProtected>
         </Instances>
@@ -903,14 +903,14 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.name, 'test analytics')
         self.assertEqual(jf.jobflowid, 'j-aaaaaa')
         self.assertEqual(jf.ec2keyname, 'my_key')
-        self.assertEqual(jf.masterinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstancetype, 'm1.large')
         self.assertEqual(jf.availabilityzone, 'us-west-1c')
         self.assertEqual(jf.keepjobflowalivewhennosteps, 'true')
-        self.assertEqual(jf.slaveinstancetype, 'm1.large')
-        self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
+        self.assertEqual(jf.subordinateinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
-        self.assertEqual(jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+        self.assertEqual(jf.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
@@ -932,7 +932,7 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(ig.market, 'ON_DEMAND')
         self.assertEqual(ig.instancegroupid, 'ig-aaaaaa')
         self.assertEqual(ig.instancerole, 'MASTER')
-        self.assertEqual(ig.name, 'Master instance group')
+        self.assertEqual(ig.name, 'Main instance group')
 
     def test_describe_jobflows_no_args(self):
         self.set_http_response(200)
@@ -1000,5 +1000,5 @@ class TestRunJobFlow(AWSMockServiceTestCase):
             'Name': 'EmrCluster' },
             ignore_params_values=['ActionOnFailure', 'Instances.InstanceCount',
                                   'Instances.KeepJobFlowAliveWhenNoSteps',
-                                  'Instances.MasterInstanceType',
-                                  'Instances.SlaveInstanceType'])
+                                  'Instances.MainInstanceType',
+                                  'Instances.SubordinateInstanceType'])

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/emr/test_emr_responses.py
@@ -85,8 +85,8 @@ JOB_FLOW_EXAMPLE = b"""
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -281,8 +281,8 @@ JOB_FLOW_COMPLETED = b"""
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -300,7 +300,7 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -315,13 +315,13 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -361,8 +361,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -379,8 +379,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/emr/test_instance_group_args.py
@@ -19,7 +19,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
-                          'SPOT', 'master')
+                          'SPOT', 'main')
 
     def test_bidprice_missing_ondemand(self):
         """
@@ -27,14 +27,14 @@ class TestInstanceGroupArgs(unittest.TestCase):
         ON_DEMAND.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'ON_DEMAND', 'master')
+                                       'ON_DEMAND', 'main')
 
     def test_bidprice_Decimal(self):
         """
         Test InstanceGroup init works with bidprice type = Decimal.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=Decimal(1.10))
+                                       'SPOT', 'main', bidprice=Decimal(1.10))
         self.assertEquals('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
@@ -42,7 +42,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = float.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=1.1)
+                                       'SPOT', 'main', bidprice=1.1)
         self.assertEquals('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
@@ -50,7 +50,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = string.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice='1.1')
+                                       'SPOT', 'main', bidprice='1.1')
         self.assertEquals('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/rds/test_connection.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/rds/test_connection.py
@@ -88,7 +88,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
                   <InstanceCreateTime>2012-10-03T22:01:51.047Z</InstanceCreateTime>
                   <AllocatedStorage>200</AllocatedStorage>
                   <DBInstanceClass>db.m1.large</DBInstanceClass>
-                  <MasterUsername>awsuser</MasterUsername>
+                  <MainUsername>awsuser</MainUsername>
                   <StatusInfos>
                     <DBInstanceStatusInfo>
                       <Message></Message>
@@ -150,7 +150,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
             db.endpoint,
             (u'mydbinstance2.c0hjqouvn9mf.us-west-2.rds.amazonaws.com', 3306))
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'awsuser')
+        self.assertEqual(db.main_username, 'awsuser')
         self.assertEqual(db.availability_zone, 'us-west-2b')
         self.assertEqual(db.backup_retention_period, 1)
         self.assertEqual(db.preferred_backup_window, '10:30-11:00')
@@ -198,7 +198,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <ReadReplicaDBInstanceIdentifiers/>
                     <Engine>mysql</Engine>
                     <PendingModifiedValues>
-                        <MasterUserPassword>****</MasterUserPassword>
+                        <MainUserPassword>****</MainUserPassword>
                     </PendingModifiedValues>
                     <BackupRetentionPeriod>0</BackupRetentionPeriod>
                     <MultiAZ>false</MultiAZ>
@@ -252,7 +252,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                         <AllocatedStorage>10</AllocatedStorage>
                         <DBInstanceClass>db.m1.large</DBInstanceClass>
-                        <MasterUsername>master</MasterUsername>
+                        <MainUsername>main</MainUsername>
                 </DBInstance>
             </CreateDBInstanceResult>
             <ResponseMetadata>
@@ -267,7 +267,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -283,8 +283,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306
         }, ignore_params_values=['Version'])
 
@@ -293,10 +293,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
 
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
@@ -312,7 +312,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group=param_group,
             db_subnet_group_name='dbSubnetgroup01')
@@ -326,8 +326,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
         }, ignore_params_values=['Version'])
 
@@ -336,10 +336,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
         self.assertEqual(db.parameter_group.description, None)
@@ -383,7 +383,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
               <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
               <AllocatedStorage>10</AllocatedStorage>
               <DBInstanceClass>db.m1.large</DBInstanceClass>
-              <MasterUsername>master</MasterUsername>
+              <MainUsername>main</MainUsername>
             </DBInstance>
           </RestoreDBInstanceToPointInTimeResult>
           <ResponseMetadata>
@@ -411,7 +411,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
 
         self.assertEqual(db.parameter_group.name,
@@ -445,7 +445,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -460,8 +460,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -481,7 +481,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -496,8 +496,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -674,9 +674,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-27 09:35:15.44 spid74      I/O is frozen on database rdsadmin. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:15.44 spid73      I/O is frozen on database master. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
+2014-01-27 09:35:15.44 spid73      I/O is frozen on database main. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:25.57 spid73      I/O was resumed on database master. No user action is required.
+2014-01-27 09:35:25.57 spid73      I/O was resumed on database main. No user action is required.
 
 2014-01-27 09:35:25.57 spid74      I/O was resumed on database rdsadmin. No user action is required.
 

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/rds/test_snapshot.py
@@ -27,7 +27,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.50</EngineVersion>
                     <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                     <PercentProgress>100</PercentProgress>
@@ -47,7 +47,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.49</EngineVersion>
                     <DBSnapshotIdentifier>mysnapshot1</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>sa</MasterUsername>
+                    <MainUsername>sa</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -64,7 +64,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.47</EngineVersion>
                     <DBSnapshotIdentifier>rds:simcoprod01-2012-04-02-00-01</DBSnapshotIdentifier>
                     <SnapshotType>automated</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -118,7 +118,7 @@ class TestCreateDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CreateDBSnapshotResult>
             <ResponseMetadata>
@@ -160,7 +160,7 @@ class TestCopyDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mycopieddbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CopyDBSnapshotResult>
             <ResponseMetadata>
@@ -202,7 +202,7 @@ class TestDeleteDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.47</EngineVersion>
                 <DBSnapshotIdentifier>mysnapshot2</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </DeleteDBSnapshotResult>
             <ResponseMetadata>
@@ -257,7 +257,7 @@ class TestRestoreDBInstanceFromDBSnapshot(AWSMockServiceTestCase):
                 <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                 <AllocatedStorage>10</AllocatedStorage>
                 <DBInstanceClass>db.m1.large</DBInstanceClass>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBInstance>
             </RestoreDBInstanceFromDBSnapshotResult>
             <ResponseMetadata>

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/route53/test_connection.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/boto/tests/unit/route53/test_connection.py
@@ -509,7 +509,7 @@ class TestTruncatedGetAllRRSetsRoute53(AWSMockServiceTestCase):
       <TTL>1800</TTL>
       <ResourceRecords>
         <ResourceRecord>
-          <Value>ns-1929.awsdns-93.net. hostmaster.awsdns.net. 1 10800 3600 604800 1800</Value>
+          <Value>ns-1929.awsdns-93.net. hostmain.awsdns.net. 1 10800 3600 604800 1800</Value>
         </ResourceRecord>
       </ResourceRecords>
     </ResourceRecordSet>

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/crcmod/docs/source/conf.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/crcmod/docs/source/conf.py
@@ -36,8 +36,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'crcmod'

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/oauth2client/docs/conf.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/oauth2client/docs/conf.py
@@ -17,7 +17,7 @@ extensions = [
 ]
 templates_path = ['_templates']
 source_suffix = '.rst'
-master_doc = 'index'
+main_doc = 'index'
 
 # General information about the project.
 project = u'oauth2client'

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/rsa/doc/conf.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/rsa/doc/conf.py
@@ -40,8 +40,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'Python-RSA'

--- a/external_bin/gsutil/gsutil_4.15/gsutil/third_party/six/documentation/conf.py
+++ b/external_bin/gsutil/gsutil_4.15/gsutil/third_party/six/documentation/conf.py
@@ -28,8 +28,8 @@ source_suffix = ".rst"
 # The encoding of source files.
 #source_encoding = "utf-8-sig"
 
-# The master toctree document.
-master_doc = "index"
+# The main toctree document.
+main_doc = "index"
 
 # General information about the project.
 project = u"six"

--- a/gclient.py
+++ b/gclient.py
@@ -244,7 +244,7 @@ class DependencySettings(GClientKeywords):
     self._custom_deps = custom_deps or {}
     self._custom_hooks = custom_hooks or []
 
-    # TODO(iannucci): Remove this when all masters are correctly substituting
+    # TODO(iannucci): Remove this when all mains are correctly substituting
     # the new blink url.
     if (self._custom_vars.get('webkit_trunk', '') ==
         'svn://svn-mirror.golo.chromium.org/webkit-readonly/trunk'):

--- a/gclient_scm.py
+++ b/gclient_scm.py
@@ -373,7 +373,7 @@ class GitWrapper(SCMWrapper):
     self._CheckMinVersion("1.6.6")
 
     # If a dependency is not pinned, track the default remote branch.
-    default_rev = 'refs/remotes/%s/master' % self.remote
+    default_rev = 'refs/remotes/%s/main' % self.remote
     url, deps_revision = gclient_utils.SplitUrlRevision(self.url)
     rev_str = ""
     revision = deps_revision
@@ -527,9 +527,9 @@ class GitWrapper(SCMWrapper):
     #      - checkout new branch
     #   c) otherwise exit
 
-    # GetUpstreamBranch returns something like 'refs/remotes/origin/master' for
+    # GetUpstreamBranch returns something like 'refs/remotes/origin/main' for
     # a tracking branch
-    # or 'master' if not a tracking branch (it's based on a specific rev/hash)
+    # or 'main' if not a tracking branch (it's based on a specific rev/hash)
     # or it returns None if it couldn't find an upstream
     if cur_branch is None:
       upstream_branch = None
@@ -749,7 +749,7 @@ class GitWrapper(SCMWrapper):
       # Don't reuse the args.
       return self.update(options, [], file_list)
 
-    default_rev = "refs/heads/master"
+    default_rev = "refs/heads/main"
     if options.upstream:
       if self._GetCurrentBranch():
         upstream_branch = scm.GIT.GetUpstreamBranch(self.checkout_path)

--- a/git_cache.py
+++ b/git_cache.py
@@ -455,7 +455,7 @@ class Mirror(object):
   def update_bootstrap(self, prune=False):
     # The files are named <git number>.zip
     gen_number = subprocess.check_output(
-        [self.git_exe, 'number', 'master'], cwd=self.mirror_path).strip()
+        [self.git_exe, 'number', 'main'], cwd=self.mirror_path).strip()
     # Run Garbage Collect to compress packfile.
     self.RunGit(['gc', '--prune=all'])
     # Creating a temp file and then deleting it ensures we can use this name.

--- a/git_common.py
+++ b/git_common.py
@@ -583,7 +583,7 @@ def parse_commitrefs(*commitrefs):
 
   A commitref is anything which can resolve to a commit. Popular examples:
     * 'HEAD'
-    * 'origin/master'
+    * 'origin/main'
     * 'cool_branch~2'
   """
   try:
@@ -634,7 +634,7 @@ def repo_root():
 
 
 def root():
-  return get_config('depot-tools.upstream', 'origin/master')
+  return get_config('depot-tools.upstream', 'origin/main')
 
 
 @contextlib.contextmanager

--- a/git_footers.py
+++ b/git_footers.py
@@ -148,9 +148,9 @@ def get_position(footers):
   Returns:
     A tuple of the branch and the position on that branch. For example,
 
-    Cr-Commit-Position: refs/heads/master@{#292272}
+    Cr-Commit-Position: refs/heads/main@{#292272}
 
-    would give the return value ('refs/heads/master', 292272).  If
+    would give the return value ('refs/heads/main', 292272).  If
     Cr-Commit-Position is not defined, we try to infer the ref and position
     from git-svn-id. The position number can be None if it was not inferrable.
   """
@@ -171,12 +171,12 @@ def get_position(footers):
       return ('refs/heads/candidates', match.group(2))
     if re.match(r'.*https?://v8\.googlecode\.com/svn/branches/bleeding_edge',
                 match.group(1)):
-      return ('refs/heads/master', match.group(2))
+      return ('refs/heads/main', match.group(2))
 
     # Assume that any trunk svn revision will match the commit-position
     # semantics.
     if re.match('.*/trunk.*$', match.group(1)):
-      return ('refs/heads/master', match.group(2))
+      return ('refs/heads/main', match.group(2))
 
     # But for now only support faking branch-heads for chrome.
     branch_match = re.match('.*/chrome/branches/([\w/-]+)/src$', match.group(1))

--- a/git_map_branches.py
+++ b/git_map_branches.py
@@ -7,7 +7,7 @@
 by their upstream ('tracking branch') layout.
 
 Example:
-origin/master
+origin/main
   cool_feature
     dependent_feature
     other_dependent_feature

--- a/git_new_branch.py
+++ b/git_new_branch.py
@@ -4,7 +4,7 @@
 # found in the LICENSE file.
 
 """
-Create new branch tracking origin/master by default.
+Create new branch tracking origin/main by default.
 """
 
 import argparse

--- a/presubmit_support.py
+++ b/presubmit_support.py
@@ -1084,12 +1084,12 @@ def ListRelevantPresubmitFiles(files, root):
   return results
 
 
-class GetTrySlavesExecuter(object):
+class GetTrySubordinatesExecuter(object):
   @staticmethod
   def ExecPresubmitScript(script_text, presubmit_path, project, change):
-    """Executes GetPreferredTrySlaves() from a single presubmit script.
+    """Executes GetPreferredTrySubordinates() from a single presubmit script.
 
-    This will soon be deprecated and replaced by GetPreferredTryMasters().
+    This will soon be deprecated and replaced by GetPreferredTryMains().
 
     Args:
       script_text: The text of the presubmit script.
@@ -1097,7 +1097,7 @@ class GetTrySlavesExecuter(object):
       project: Project name to pass to presubmit script for bot selection.
 
     Return:
-      A list of try slaves.
+      A list of try subordinates.
     """
     context = {}
     main_path = os.getcwd()
@@ -1109,16 +1109,16 @@ class GetTrySlavesExecuter(object):
     finally:
       os.chdir(main_path)
 
-    function_name = 'GetPreferredTrySlaves'
+    function_name = 'GetPreferredTrySubordinates'
     if function_name in context:
-      get_preferred_try_slaves = context[function_name]
-      function_info = inspect.getargspec(get_preferred_try_slaves)
+      get_preferred_try_subordinates = context[function_name]
+      function_info = inspect.getargspec(get_preferred_try_subordinates)
       if len(function_info[0]) == 1:
-        result = get_preferred_try_slaves(project)
+        result = get_preferred_try_subordinates(project)
       elif len(function_info[0]) == 2:
-        result = get_preferred_try_slaves(project, change)
+        result = get_preferred_try_subordinates(project, change)
       else:
-        result = get_preferred_try_slaves()
+        result = get_preferred_try_subordinates()
       if not isinstance(result, types.ListType):
         raise PresubmitFailure(
             'Presubmit functions must return a list, got a %s instead: %s' %
@@ -1131,12 +1131,12 @@ class GetTrySlavesExecuter(object):
           # New-style [('bot', set(['tests']))] format.
           botname = item[0]
         else:
-          raise PresubmitFailure('PRESUBMIT.py returned invalid tryslave/test'
+          raise PresubmitFailure('PRESUBMIT.py returned invalid trysubordinate/test'
                                  ' format.')
 
         if botname != botname.strip():
           raise PresubmitFailure(
-              'Try slave names cannot start/end with whitespace')
+              'Try subordinate names cannot start/end with whitespace')
         if ',' in botname:
           raise PresubmitFailure(
               'Do not use \',\' separated builder or test names: %s' % botname)
@@ -1161,10 +1161,10 @@ class GetTrySlavesExecuter(object):
     return result
 
 
-class GetTryMastersExecuter(object):
+class GetTryMainsExecuter(object):
   @staticmethod
   def ExecPresubmitScript(script_text, presubmit_path, project, change):
-    """Executes GetPreferredTryMasters() from a single presubmit script.
+    """Executes GetPreferredTryMains() from a single presubmit script.
 
     Args:
       script_text: The text of the presubmit script.
@@ -1172,7 +1172,7 @@ class GetTryMastersExecuter(object):
       project: Project name to pass to presubmit script for bot selection.
 
     Return:
-      A map of try masters to map of builders to set of tests.
+      A map of try mains to map of builders to set of tests.
     """
     context = {}
     try:
@@ -1181,14 +1181,14 @@ class GetTryMastersExecuter(object):
       raise PresubmitFailure('"%s" had an exception.\n%s'
                              % (presubmit_path, e))
 
-    function_name = 'GetPreferredTryMasters'
+    function_name = 'GetPreferredTryMains'
     if function_name not in context:
       return {}
-    get_preferred_try_masters = context[function_name]
-    if not len(inspect.getargspec(get_preferred_try_masters)[0]) == 2:
+    get_preferred_try_mains = context[function_name]
+    if not len(inspect.getargspec(get_preferred_try_mains)[0]) == 2:
       raise PresubmitFailure(
-          'Expected function "GetPreferredTryMasters" to take two arguments.')
-    return get_preferred_try_masters(project, change)
+          'Expected function "GetPreferredTryMains" to take two arguments.')
+    return get_preferred_try_mains(project, change)
 
 
 class GetPostUploadExecuter(object):
@@ -1222,7 +1222,7 @@ class GetPostUploadExecuter(object):
     return post_upload_hook(cl, change, OutputApi(False))
 
 
-def DoGetTrySlaves(change,
+def DoGetTrySubordinates(change,
                    changed_files,
                    repository_root,
                    default_presubmit,
@@ -1240,13 +1240,13 @@ def DoGetTrySlaves(change,
     output_stream: A stream to write debug output to.
 
   Return:
-    List of try slaves
+    List of try subordinates
   """
   presubmit_files = ListRelevantPresubmitFiles(changed_files, repository_root)
   if not presubmit_files and verbose:
     output_stream.write("Warning, no PRESUBMIT.py found.\n")
   results = []
-  executer = GetTrySlavesExecuter()
+  executer = GetTrySubordinatesExecuter()
 
   if default_presubmit:
     if verbose:
@@ -1264,41 +1264,41 @@ def DoGetTrySlaves(change,
         presubmit_script, filename, project, change))
 
 
-  slave_dict = {}
+  subordinate_dict = {}
   old_style = filter(lambda x: isinstance(x, basestring), results)
   new_style = filter(lambda x: isinstance(x, tuple), results)
 
   for result in new_style:
-    slave_dict.setdefault(result[0], set()).update(result[1])
-  slaves = list(slave_dict.items())
+    subordinate_dict.setdefault(result[0], set()).update(result[1])
+  subordinates = list(subordinate_dict.items())
 
-  slaves.extend(set(old_style))
+  subordinates.extend(set(old_style))
 
-  if slaves and verbose:
-    output_stream.write(', '.join((str(x) for x in slaves)))
+  if subordinates and verbose:
+    output_stream.write(', '.join((str(x) for x in subordinates)))
     output_stream.write('\n')
-  return slaves
+  return subordinates
 
 
-def _MergeMasters(masters1, masters2):
-  """Merges two master maps. Merges also the tests of each builder."""
+def _MergeMains(mains1, mains2):
+  """Merges two main maps. Merges also the tests of each builder."""
   result = {}
-  for (master, builders) in itertools.chain(masters1.iteritems(),
-                                            masters2.iteritems()):
-    new_builders = result.setdefault(master, {})
+  for (main, builders) in itertools.chain(mains1.iteritems(),
+                                            mains2.iteritems()):
+    new_builders = result.setdefault(main, {})
     for (builder, tests) in builders.iteritems():
       new_builders.setdefault(builder, set([])).update(tests)
   return result
 
 
-def DoGetTryMasters(change,
+def DoGetTryMains(change,
                     changed_files,
                     repository_root,
                     default_presubmit,
                     project,
                     verbose,
                     output_stream):
-  """Get the list of try masters from the presubmit scripts.
+  """Get the list of try mains from the presubmit scripts.
 
   Args:
     changed_files: List of modified files.
@@ -1309,19 +1309,19 @@ def DoGetTryMasters(change,
     output_stream: A stream to write debug output to.
 
   Return:
-    Map of try masters to map of builders to set of tests.
+    Map of try mains to map of builders to set of tests.
   """
   presubmit_files = ListRelevantPresubmitFiles(changed_files, repository_root)
   if not presubmit_files and verbose:
     output_stream.write("Warning, no PRESUBMIT.py found.\n")
   results = {}
-  executer = GetTryMastersExecuter()
+  executer = GetTryMainsExecuter()
 
   if default_presubmit:
     if verbose:
       output_stream.write("Running default presubmit script.\n")
     fake_path = os.path.join(repository_root, 'PRESUBMIT.py')
-    results = _MergeMasters(results, executer.ExecPresubmitScript(
+    results = _MergeMains(results, executer.ExecPresubmitScript(
         default_presubmit, fake_path, project, change))
   for filename in presubmit_files:
     filename = os.path.abspath(filename)
@@ -1329,7 +1329,7 @@ def DoGetTryMasters(change,
       output_stream.write("Running %s\n" % filename)
     # Accept CRLF presubmit script.
     presubmit_script = gclient_utils.FileRead(filename, 'rU')
-    results = _MergeMasters(results, executer.ExecPresubmitScript(
+    results = _MergeMains(results, executer.ExecPresubmitScript(
         presubmit_script, filename, project, change))
 
   # Make sets to lists again for later JSON serialization.

--- a/recipe_modules/bot_update/api.py
+++ b/recipe_modules/bot_update/api.py
@@ -294,7 +294,7 @@ class BotUpdateApi(recipe_api.RecipeApi):
         # first solution.
         if step_result.json.output['did_run']:
           co_root = step_result.json.output['root']
-          cwd = kwargs.get('cwd', self.m.path['slave_build'])
+          cwd = kwargs.get('cwd', self.m.path['subordinate_build'])
           if 'checkout' not in self.m.path:
             self.m.path['checkout'] = cwd.join(*co_root.split(self.m.path.sep))
 

--- a/recipe_modules/bot_update/example.py
+++ b/recipe_modules/bot_update/example.py
@@ -82,15 +82,15 @@ def GenTests(api):
       oauth2=True,
   )
   yield api.test('trychange_oauth2_json') + api.properties(
-      mastername='tryserver.chromium.linux',
+      mainname='tryserver.chromium.linux',
       buildername='linux_rel',
-      slavename='totallyaslave-c4',
+      subordinatename='totallyasubordinate-c4',
       oauth2_json=True,
   )
   yield api.test('trychange_oauth2_json_win') + api.properties(
-      mastername='tryserver.chromium.win',
+      mainname='tryserver.chromium.win',
       buildername='win_rel',
-      slavename='totallyaslave-c4',
+      subordinatename='totallyasubordinate-c4',
       oauth2_json=True,
   ) + api.platform('win', 64)
   yield api.test('tryjob_fail') + api.properties(

--- a/recipe_modules/bot_update/resources/bot_update.py
+++ b/recipe_modules/bot_update/resources/bot_update.py
@@ -446,7 +446,7 @@ def get_target_revision(folder_name, git_url, revisions):
 
 def force_revision(folder_name, revision):
   split_revision = revision.split(':', 1)
-  branch = 'master'
+  branch = 'main'
   if len(split_revision) == 2:
     # Support for "branch:revision" syntax.
     branch, revision = split_revision

--- a/recipe_modules/bot_update/test_api.py
+++ b/recipe_modules/bot_update/test_api.py
@@ -23,7 +23,7 @@ class BotUpdateTestApi(recipe_test_api.RecipeTestApi):
         for project_name, property_name in revision_mapping.iteritems()
     }
     properties.update({
-        '%s_cp' % property_name: ('refs/heads/master@{#%s}' %
+        '%s_cp' % property_name: ('refs/heads/main@{#%s}' %
                                   self.gen_commit_position(project_name))
         for project_name, property_name in revision_mapping.iteritems()
     })

--- a/recipe_modules/cipd/api.py
+++ b/recipe_modules/cipd/api.py
@@ -51,7 +51,7 @@ class CIPDApi(recipe_api.RecipeApi):
         script=self.resource('bootstrap.py'),
         args=[
           '--platform', self.platform_suffix(),
-          '--dest-directory', self.m.path['slave_build'].join('cipd'),
+          '--dest-directory', self.m.path['subordinate_build'].join('cipd'),
           '--json-output', self.m.json.output(),
         ] +
         (['--version', version] if version else []),

--- a/recipe_modules/cipd/example.py
+++ b/recipe_modules/cipd/example.py
@@ -24,7 +24,7 @@ def RunSteps(api):
   package_instance_id = '7f751b2237df2fdf3c1405be00590fefffbaea2d'
   packages = {package_name: package_instance_id}
 
-  cipd_root = api.path['slave_build'].join('packages')
+  cipd_root = api.path['subordinate_build'].join('packages')
   # Some packages don't require credentials to be installed or queried.
   api.cipd.ensure(cipd_root, packages)
   step = api.cipd.search(package_name, tag='git_revision:40-chars-long-hash')
@@ -54,7 +54,7 @@ def RunSteps(api):
                           'fake_tag_2': 'fake_value_2'})
 
   # Create (build & register).
-  api.cipd.create(api.path['slave_build'].join('fake-package.yaml'),
+  api.cipd.create(api.path['subordinate_build'].join('fake-package.yaml'),
                   refs=['fake-ref-1', 'fake-ref-2'],
                   tags={'fake_tag_1': 'fake_value_1',
                         'fake_tag_2': 'fake_value_2'})

--- a/recipe_modules/cipd/test_api.py
+++ b/recipe_modules/cipd/test_api.py
@@ -30,7 +30,7 @@ class CIPDTestApi(recipe_test_api.RecipeTestApi):
     return self.m.json.output(dic, retcode=retcode)
 
   def make_test_executable(self):
-    return str(self.m.path['slave_build'].join('cipd', 'cipd'))
+    return str(self.m.path['subordinate_build'].join('cipd', 'cipd'))
 
   def example_error(self, error, retcode=None):
     return self._resultify(

--- a/recipe_modules/gclient/api.py
+++ b/recipe_modules/gclient/api.py
@@ -161,7 +161,7 @@ class GclientApi(recipe_api.RecipeApi):
       # operations.
       #
       # TODO(mmoss): To be like current official builders, this step could
-      # just delete the whole <slave_name>/build/ directory and start each
+      # just delete the whole <subordinate_name>/build/ directory and start each
       # build from scratch. That might be the least bad solution, at least
       # until we have a reliable gclient method to produce a pristine working
       # dir for git-based builds (e.g. maybe some combination of 'git
@@ -240,7 +240,7 @@ class GclientApi(recipe_api.RecipeApi):
         name = 'recurse (git config %s)' % var
         self(name, ['recurse', 'git', 'config', var, val], **kwargs)
     finally:
-      cwd = kwargs.get('cwd', self.m.path['slave_build'])
+      cwd = kwargs.get('cwd', self.m.path['subordinate_build'])
       if 'checkout' not in self.m.path:
         self.m.path['checkout'] = cwd.join(
           *cfg.solutions[0].name.split(self.m.path.sep))
@@ -254,7 +254,7 @@ class GclientApi(recipe_api.RecipeApi):
     prefix = '%sgclient ' % (('[spec: %s] ' % alias) if alias else '')
 
     return self.m.python(prefix + 'revert',
-        self.m.path['build'].join('scripts', 'slave', 'gclient_safe_revert.py'),
+        self.m.path['build'].join('scripts', 'subordinate', 'gclient_safe_revert.py'),
         ['.', self.m.path['depot_tools'].join('gclient',
                                               platform_ext={'win': '.bat'})],
         infra_step=True,
@@ -299,7 +299,7 @@ class GclientApi(recipe_api.RecipeApi):
                 print 'deleting %s' % path_to_file
                 os.remove(path_to_file)
       """,
-      args=[self.m.path['slave_build']],
+      args=[self.m.path['subordinate_build']],
       infra_step=True,
     )
 

--- a/recipe_modules/gclient/config.py
+++ b/recipe_modules/gclient/config.py
@@ -74,7 +74,7 @@ def BaseConfig(USE_MIRROR=True, CACHE_DIR=None,
     # For example, bare chromium solution has this entry in patch_projects
     #     'angle/angle': ('src/third_party/angle', 'HEAD')
     # then a patch to Angle project can be applied to a chromium src's
-    # checkout after first updating Angle's repo to its master's HEAD.
+    # checkout after first updating Angle's repo to its main's HEAD.
     patch_projects = Dict(value_type=tuple, hidden=True),
 
     # Check out refs/branch-heads.
@@ -268,7 +268,7 @@ def wasm_llvm(c):
       c, 'external', 'github.com', 'WebAssembly', 'waterfall.git')
   m = c.got_revision_mapping
   m['src'] = 'got_waterfall_revision'
-  c.revisions['src'] = 'origin/master'
+  c.revisions['src'] = 'origin/main'
 
 @config_ctx()
 def gyp(c):
@@ -322,12 +322,12 @@ def build_internal(c):
   c.got_revision_mapping['build'] = 'got_build_revision'
 
 @config_ctx()
-def build_internal_scripts_slave(c):
+def build_internal_scripts_subordinate(c):
   s = c.solutions.add()
-  s.name = 'build_internal/scripts/slave'
+  s.name = 'build_internal/scripts/subordinate'
   s.url = ('https://chrome-internal.googlesource.com/'
-           'chrome/tools/build_limited/scripts/slave.git')
-  c.got_revision_mapping['build_internal/scripts/slave'] = 'got_revision'
+           'chrome/tools/build_limited/scripts/subordinate.git')
+  c.got_revision_mapping['build_internal/scripts/subordinate'] = 'got_revision'
   # We do not use 'includes' here, because we want build_internal to be the
   # first solution in the list as run_presubmit computes upstream revision
   # from the first solution.
@@ -335,20 +335,20 @@ def build_internal_scripts_slave(c):
   c.got_revision_mapping['build'] = 'got_build_revision'
 
 @config_ctx()
-def master_deps(c):
+def main_deps(c):
   s = c.solutions.add()
-  s.name = 'build_internal/master.DEPS'
+  s.name = 'build_internal/main.DEPS'
   s.url = ('https://chrome-internal.googlesource.com/'
-           'chrome/tools/build/master.DEPS.git')
-  c.got_revision_mapping['build_internal/master.DEPS'] = 'got_revision'
+           'chrome/tools/build/main.DEPS.git')
+  c.got_revision_mapping['build_internal/main.DEPS'] = 'got_revision'
 
 @config_ctx()
-def slave_deps(c):
+def subordinate_deps(c):
   s = c.solutions.add()
-  s.name = 'build_internal/slave.DEPS'
+  s.name = 'build_internal/subordinate.DEPS'
   s.url = ('https://chrome-internal.googlesource.com/'
-           'chrome/tools/build/slave.DEPS.git')
-  c.got_revision_mapping['build_internal/slave.DEPS'] = 'got_revision'
+           'chrome/tools/build/subordinate.DEPS.git')
+  c.got_revision_mapping['build_internal/subordinate.DEPS'] = 'got_revision'
 
 @config_ctx()
 def internal_deps(c):
@@ -382,7 +382,7 @@ def chromium_skia(c):
   c.solutions[0].revision = 'HEAD'
   del c.solutions[0].custom_deps
   c.revisions['src/third_party/skia'] = (
-      gclient_api.RevisionFallbackChain('origin/master'))
+      gclient_api.RevisionFallbackChain('origin/main'))
   c.got_revision_mapping['src'] = 'got_chromium_revision'
   c.got_revision_mapping['src/third_party/skia'] = 'got_revision'
   c.parent_got_revision_mapping['parent_got_revision'] = 'got_revision'
@@ -472,11 +472,11 @@ def infra_internal(c):  # pragma: no cover
 @config_ctx(includes=['infra'])
 def luci_gae(c):
   # luci/gae is checked out as a part of infra.git solution at HEAD.
-  c.revisions['infra'] = 'origin/master'
+  c.revisions['infra'] = 'origin/main'
   # luci/gae is developed together with luci-go, which should be at HEAD.
-  c.revisions['infra/go/src/github.com/luci/luci-go'] = 'origin/master'
+  c.revisions['infra/go/src/github.com/luci/luci-go'] = 'origin/main'
   c.revisions['infra/go/src/github.com/luci/gae'] = (
-      gclient_api.RevisionFallbackChain('origin/master'))
+      gclient_api.RevisionFallbackChain('origin/main'))
   m = c.got_revision_mapping
   del m['infra']
   m['infra/go/src/github.com/luci/gae'] = 'got_revision'
@@ -484,9 +484,9 @@ def luci_gae(c):
 @config_ctx(includes=['infra'])
 def luci_go(c):
   # luci-go is checked out as a part of infra.git solution at HEAD.
-  c.revisions['infra'] = 'origin/master'
+  c.revisions['infra'] = 'origin/main'
   c.revisions['infra/go/src/github.com/luci/luci-go'] = (
-      gclient_api.RevisionFallbackChain('origin/master'))
+      gclient_api.RevisionFallbackChain('origin/main'))
   m = c.got_revision_mapping
   del m['infra']
   m['infra/go/src/github.com/luci/luci-go'] = 'got_revision'
@@ -495,20 +495,20 @@ def luci_go(c):
 def luci_py(c):
   # luci-py is checked out as part of infra just to have appengine
   # pre-installed, as that's what luci-py PRESUBMIT relies on.
-  c.revisions['infra'] = 'origin/master'
+  c.revisions['infra'] = 'origin/main'
   # TODO(tandrii): make use of c.patch_projects.
   c.revisions['infra/luci'] = (
-      gclient_api.RevisionFallbackChain('origin/master'))
+      gclient_api.RevisionFallbackChain('origin/main'))
   m = c.got_revision_mapping
   del m['infra']
   m['infra/luci'] = 'got_revision'
 
 @config_ctx(includes=['infra'])
 def recipes_py(c):
-  c.revisions['infra'] = 'origin/master'
+  c.revisions['infra'] = 'origin/main'
   # TODO(tandrii): make use of c.patch_projects.
   c.revisions['infra/recipes-py'] = (
-      gclient_api.RevisionFallbackChain('origin/master'))
+      gclient_api.RevisionFallbackChain('origin/main'))
   m = c.got_revision_mapping
   del m['infra']
   m['infra/recipes-py'] = 'got_revision'
@@ -530,12 +530,12 @@ def catapult(c):
   c.got_revision_mapping['catapult'] = 'got_revision'
 
 @config_ctx(includes=['infra_internal'])
-def infradata_master_manager(c):
+def infradata_main_manager(c):
   soln = c.solutions.add()
-  soln.name = 'infra-data-master-manager'
+  soln.name = 'infra-data-main-manager'
   soln.url = (
       'https://chrome-internal.googlesource.com/infradata/master-manager.git')
-  c.got_revision_mapping['infra-data-master-manager'] = 'got_revision'
+  c.got_revision_mapping['infra-data-main-manager'] = 'got_revision'
 
 @config_ctx()
 def with_branch_heads(c):

--- a/recipe_modules/gclient/example.py
+++ b/recipe_modules/gclient/example.py
@@ -15,7 +15,7 @@ TEST_CONFIGS = [
   'blink',
   'boringssl',
   'build_internal',
-  'build_internal_scripts_slave',
+  'build_internal_scripts_subordinate',
   'catapult',
   'chromedriver',
   'chrome_internal',
@@ -33,13 +33,13 @@ TEST_CONFIGS = [
   'gerrit_test_cq_normal',
   'gyp',
   'infra',
-  'infradata_master_manager',
+  'infradata_main_manager',
   'internal_deps',
   'ios',
   'luci_gae',
   'luci_go',
   'luci_py',
-  'master_deps',
+  'main_deps',
   'mojo',
   'nacl',
   'pdfium',
@@ -47,7 +47,7 @@ TEST_CONFIGS = [
   'recipes_py',
   'recipes_py_bare',
   'show_v8_revision',
-  'slave_deps',
+  'subordinate_deps',
   'v8_bleeding_edge_git',
   'v8_canary',
   'wasm_llvm',
@@ -81,7 +81,7 @@ def RunSteps(api):
   api.gclient.checkout(
       gclient_config=bl_cfg,
       with_branch_heads=True,
-      cwd=api.path['slave_build'].join('src', 'third_party'))
+      cwd=api.path['subordinate_build'].join('src', 'third_party'))
 
   api.gclient.break_locks()
 

--- a/recipe_modules/git/api.py
+++ b/recipe_modules/git/api.py
@@ -186,7 +186,7 @@ class GitApi(recipe_api.RecipeApi):
       # ex: ssh://host:repo/foobar/.git
       dir_path = dir_path or dir_path.rsplit('/', 1)[-1]
 
-      dir_path = self.m.path['slave_build'].join(dir_path)
+      dir_path = self.m.path['subordinate_build'].join(dir_path)
 
     if 'checkout' not in self.m.path:
       self.m.path['checkout'] = dir_path
@@ -236,16 +236,16 @@ class GitApi(recipe_api.RecipeApi):
     # 0) None. In this case, we default to properties['branch'].
     # 1) A 40-character SHA1 hash.
     # 2) A fully-qualifed arbitrary ref, e.g. 'refs/foo/bar/baz'.
-    # 3) A fully qualified branch name, e.g. 'refs/heads/master'.
+    # 3) A fully qualified branch name, e.g. 'refs/heads/main'.
     #    Chop off 'refs/heads' and now it matches case (4).
-    # 4) A branch name, e.g. 'master'.
+    # 4) A branch name, e.g. 'main'.
     # Note that 'FETCH_HEAD' can be many things (and therefore not a valid
     # checkout target) if many refs are fetched, but we only explicitly fetch
     # one ref here, so this is safe.
     fetch_args = []
     if not ref:                                  # Case 0
       fetch_remote = remote_name
-      fetch_ref = self.m.properties.get('branch') or 'master'
+      fetch_ref = self.m.properties.get('branch') or 'main'
       checkout_ref = 'FETCH_HEAD'
     elif self._GIT_HASH_RE.match(ref):        # Case 1.
       fetch_remote = remote_name
@@ -363,7 +363,7 @@ class GitApi(recipe_api.RecipeApi):
     """
     remote_name = remote_name or 'origin'
     try:
-      self('rebase', '%s/master' % remote_name,
+      self('rebase', '%s/main' % remote_name,
           name="%s rebase" % name_prefix, cwd=dir_path, **kwargs)
     except self.m.step.StepFailure:
       self('rebase', '--abort', name='%s rebase abort' % name_prefix,
@@ -416,7 +416,7 @@ class GitApi(recipe_api.RecipeApi):
     Args:
       branch (str): new branch name, which must not yet exist.
       name (str): step name.
-      upstream (str): to origin/master.
+      upstream (str): to origin/main.
       kwargs: Forwarded to '__call__'.
     """
     env = kwargs.pop('env', {})

--- a/recipe_modules/git/example.py
+++ b/recipe_modules/git/example.py
@@ -19,7 +19,7 @@ def RunSteps(api):
   # useful for debugging git access issues that are reproducible only on bots.
   curl_trace_file = None
   if api.properties.get('use_curl_trace'):
-    curl_trace_file = api.path['slave_build'].join('curl_trace.log')
+    curl_trace_file = api.path['subordinate_build'].join('curl_trace.log')
 
   submodule_update_force = api.properties.get('submodule_update_force', False)
   submodule_update_recursive = api.properties.get('submodule_update_recursive',
@@ -68,12 +68,12 @@ def RunSteps(api):
           can_fail_build=False)
 
   # You should run git new-branch before you upload something with git cl.
-  api.git.new_branch('refactor')  # Upstream is origin/master by default.
+  api.git.new_branch('refactor')  # Upstream is origin/main by default.
   # And use upstream kwarg to set up different upstream for tracking.
   api.git.new_branch('feature', upstream='refactor')
 
   # You can use api.git.rebase to rebase the current branch onto another one
-  api.git.rebase(name_prefix='my repo', branch='origin/master',
+  api.git.rebase(name_prefix='my repo', branch='origin/main',
                  dir_path=api.path['checkout'],
                  remote_name=api.properties.get('remote_name'))
 
@@ -86,7 +86,7 @@ def RunSteps(api):
 
   # Bundle the repository.
   api.git.bundle_create(
-        api.path['slave_build'].join('all.bundle'))
+        api.path['subordinate_build'].join('all.bundle'))
 
 
 def GenTests(api):

--- a/recipe_modules/infra_paths/path_config.py
+++ b/recipe_modules/infra_paths/path_config.py
@@ -14,13 +14,13 @@ def infra_common(c):
 @CONFIG_CTX(includes=['infra_common'])
 def infra_buildbot(c):
   c.base_paths['root'] = c.CURRENT_WORKING_DIR[:-4]
-  c.base_paths['slave_build'] = c.CURRENT_WORKING_DIR
+  c.base_paths['subordinate_build'] = c.CURRENT_WORKING_DIR
   c.base_paths['cache'] = c.base_paths['root'] + (
-      'build', 'slave', 'cache')
+      'build', 'subordinate', 'cache')
   c.base_paths['git_cache'] = c.base_paths['root'] + (
-      'build', 'slave', 'cache_dir')
+      'build', 'subordinate', 'cache_dir')
   c.base_paths['goma_cache'] = c.base_paths['root'] + (
-      'build', 'slave', 'goma_cache')
+      'build', 'subordinate', 'goma_cache')
   for token in ('build_internal', 'build', 'depot_tools'):
     c.base_paths[token] = c.base_paths['root'] + (token,)
 
@@ -28,7 +28,7 @@ def infra_buildbot(c):
 @CONFIG_CTX(includes=['infra_common'])
 def infra_kitchen(c):
   c.base_paths['root'] = c.CURRENT_WORKING_DIR
-  c.base_paths['slave_build'] = c.CURRENT_WORKING_DIR
+  c.base_paths['subordinate_build'] = c.CURRENT_WORKING_DIR
   # TODO(phajdan.jr): have one cache dir, let clients append suffixes.
 
   b_dir = c.CURRENT_WORKING_DIR

--- a/recipe_modules/rietveld/example.py
+++ b/recipe_modules/rietveld/example.py
@@ -11,7 +11,7 @@ DEPS = [
 ]
 
 def RunSteps(api):
-  api.path['checkout'] = api.path['slave_build']
+  api.path['checkout'] = api.path['subordinate_build']
   api.rietveld.apply_issue('foo', 'bar', authentication='oauth2')
   api.rietveld.calculate_issue_root({'project': ['']})
 

--- a/recipe_modules/tryserver/api.py
+++ b/recipe_modules/tryserver/api.py
@@ -101,7 +101,7 @@ class TryserverApi(recipe_api.RecipeApi):
     patch_ref = self.m.properties['patch_ref']
 
     patch_dir = self.m.path.mkdtemp('patch')
-    git_setup_py = self.m.path['build'].join('scripts', 'slave', 'git_setup.py')
+    git_setup_py = self.m.path['build'].join('scripts', 'subordinate', 'git_setup.py')
     git_setup_args = ['--path', patch_dir, '--url', patch_repo_url]
     patch_path = patch_dir.join('patch.diff')
 
@@ -167,7 +167,7 @@ class TryserverApi(recipe_api.RecipeApi):
     if patch_root is None:
       return self._old_get_files_affected_by_patch()
     if not kwargs.get('cwd'):
-      kwargs['cwd'] = self.m.path['slave_build'].join(patch_root)
+      kwargs['cwd'] = self.m.path['subordinate_build'].join(patch_root)
     step_result = self.m.git('diff', '--cached', '--name-only',
                              name='git diff to analyze patch',
                              stdout=self.m.raw_io.output(),

--- a/recipe_modules/tryserver/example.py
+++ b/recipe_modules/tryserver/example.py
@@ -15,7 +15,7 @@ DEPS = [
 
 
 def RunSteps(api):
-  api.path['checkout'] = api.path['slave_build']
+  api.path['checkout'] = api.path['subordinate_build']
   if api.properties.get('patch_text'):
     api.step('patch_text test', [
         'echo', str(api.tryserver.get_footers(api.properties['patch_text']))])

--- a/rietveld.py
+++ b/rietveld.py
@@ -344,11 +344,11 @@ class Rietveld(object):
 
   def trigger_try_jobs(
       self, issue, patchset, reason, clobber, revision, builders_and_tests,
-      master=None, category='cq'):
+      main=None, category='cq'):
     """Requests new try jobs.
 
     |builders_and_tests| is a map of builders: [tests] to run.
-    |master| is the name of the try master the builders belong to.
+    |main| is the name of the try main the builders belong to.
     |category| is used to distinguish regular jobs and experimental jobs.
 
     Returns the keys of the new TryJobResult entites.
@@ -362,25 +362,25 @@ class Rietveld(object):
     ]
     if revision:
       params.append(('revision', revision))
-    if master:
-      # Temporarily allow empty master names for old configurations. The try
-      # job will not be associated with a master name on rietveld. This is
+    if main:
+      # Temporarily allow empty main names for old configurations. The try
+      # job will not be associated with a main name on rietveld. This is
       # going to be deprecated.
-      params.append(('master', master))
+      params.append(('main', main))
     return self.post('/%d/try/%d' % (issue, patchset), params)
 
   def trigger_distributed_try_jobs(
-      self, issue, patchset, reason, clobber, revision, masters,
+      self, issue, patchset, reason, clobber, revision, mains,
       category='cq'):
     """Requests new try jobs.
 
-    |masters| is a map of masters: map of builders: [tests] to run.
+    |mains| is a map of mains: map of builders: [tests] to run.
     |category| is used to distinguish regular jobs and experimental jobs.
     """
-    for (master, builders_and_tests) in masters.iteritems():
+    for (main, builders_and_tests) in mains.iteritems():
       self.trigger_try_jobs(
           issue, patchset, reason, clobber, revision, builders_and_tests,
-          master, category)
+          main, category)
 
   def get_pending_try_jobs(self, cursor=None, limit=100):
     """Retrieves the try job requests in pending state.
@@ -756,12 +756,12 @@ class ReadOnlyRietveld(object):
 
   def trigger_try_jobs(  # pylint:disable=R0201
       self, issue, patchset, reason, clobber, revision, builders_and_tests,
-      master=None, category='cq'):
+      main=None, category='cq'):
     logging.info('ReadOnlyRietveld: triggering try jobs %r for issue %d' %
         (builders_and_tests, issue))
 
   def trigger_distributed_try_jobs(  # pylint:disable=R0201
-      self, issue, patchset, reason, clobber, revision, masters,
+      self, issue, patchset, reason, clobber, revision, mains,
       category='cq'):
     logging.info('ReadOnlyRietveld: triggering try jobs %r for issue %d' %
-        (masters, issue))
+        (mains, issue))

--- a/roll_dep.py
+++ b/roll_dep.py
@@ -6,7 +6,7 @@
 """Rolls DEPS controlled dependency.
 
 Works only with git checkout and git dependencies.  Currently this
-script will always roll to the tip of to origin/master.
+script will always roll to the tip of to origin/main.
 """
 
 import argparse
@@ -38,23 +38,23 @@ def check_call(*args, **kwargs):
   subprocess.check_call(*args, **kwargs)
 
 
-def is_pristine(root, merge_base='origin/master'):
+def is_pristine(root, merge_base='origin/main'):
   """Returns True if a git checkout is pristine."""
   cmd = ['git', 'diff', '--ignore-submodules', merge_base]
   return not (check_output(cmd, cwd=root).strip() or
               check_output(cmd + ['--cached'], cwd=root).strip())
 
 
-def get_log_url(upstream_url, head, master):
+def get_log_url(upstream_url, head, main):
   """Returns an URL to read logs via a Web UI if applicable."""
   if re.match(r'https://[^/]*\.googlesource\.com/', upstream_url):
     # gitiles
-    return '%s/+log/%s..%s' % (upstream_url, head[:12], master[:12])
+    return '%s/+log/%s..%s' % (upstream_url, head[:12], main[:12])
   if upstream_url.startswith('https://github.com/'):
     upstream_url = upstream_url.rstrip('/')
     if upstream_url.endswith('.git'):
       upstream_url = upstream_url[:-len('.git')]
-    return '%s/compare/%s...%s' % (upstream_url, head[:12], master[:12])
+    return '%s/compare/%s...%s' % (upstream_url, head[:12], main[:12])
   return None
 
 
@@ -188,7 +188,7 @@ def main():
       '--log-limit', type=int, default=100,
       help='Trim log after N commits (default: %(default)s)')
   parser.add_argument(
-      '--roll-to', default='origin/master',
+      '--roll-to', default='origin/main',
       help='Specify the new commit to roll to (default: %(default)s)')
   parser.add_argument('dep_path', help='Path to dependency')
   parser.add_argument('key', nargs='?',

--- a/roll_dep_svn.py
+++ b/roll_dep_svn.py
@@ -119,7 +119,7 @@ def convert_svn_revision(dep_path, revision):
   revision = int(revision)
   latest_svn_rev = None
   with open(os.devnull, 'w') as devnull:
-    for ref in ('HEAD', 'origin/master'):
+    for ref in ('HEAD', 'origin/main'):
       try:
         log_p = Popen(['git', 'log', ref],
                       cwd=dep_path, stdout=PIPE, stderr=devnull)

--- a/scm.py
+++ b/scm.py
@@ -176,12 +176,12 @@ class GIT(object):
 
   @staticmethod
   def GetBranchRef(cwd):
-    """Returns the full branch reference, e.g. 'refs/heads/master'."""
+    """Returns the full branch reference, e.g. 'refs/heads/main'."""
     return GIT.Capture(['symbolic-ref', 'HEAD'], cwd=cwd)
 
   @staticmethod
   def GetBranch(cwd):
-    """Returns the short branch name, e.g. 'master'."""
+    """Returns the short branch name, e.g. 'main'."""
     return GIT.ShortBranchName(GIT.GetBranchRef(cwd))
 
   @staticmethod
@@ -302,7 +302,7 @@ class GIT(object):
   @staticmethod
   def FetchUpstreamTuple(cwd):
     """Returns a tuple containg remote and remote ref,
-       e.g. 'origin', 'refs/heads/master'
+       e.g. 'origin', 'refs/heads/main'
        Tries to be intelligent and understand git-svn.
     """
     remote = '.'
@@ -337,10 +337,10 @@ class GIT(object):
         else:
           # Else, try to guess the origin remote.
           remote_branches = GIT.Capture(['branch', '-r'], cwd=cwd).split()
-          if 'origin/master' in remote_branches:
-            # Fall back on origin/master if it exits.
+          if 'origin/main' in remote_branches:
+            # Fall back on origin/main if it exits.
             remote = 'origin'
-            upstream_branch = 'refs/heads/master'
+            upstream_branch = 'refs/heads/main'
           elif 'origin/trunk' in remote_branches:
             # Fall back on origin/trunk if it exists. Generally a shared
             # git-svn clone
@@ -481,7 +481,7 @@ class GIT(object):
 
   @staticmethod
   def GetBlessedSha1ForSvnRev(cwd, rev):
-    """Returns a git commit hash from the master branch history that has
+    """Returns a git commit hash from the main branch history that has
     accurate .DEPS.git and git submodules.  To understand why this is more
     complicated than a simple call to `git svn find-rev`, refer to:
 

--- a/testing_support/gerrit_test_case.py
+++ b/testing_support/gerrit_test_case.py
@@ -292,24 +292,24 @@ class GerritTestCase(unittest.TestCase):
     return self._GetCommit(clone_path, ref)
 
   @classmethod
-  def _UploadChange(cls, clone_path, branch='master', remote='origin'):
+  def _UploadChange(cls, clone_path, branch='main', remote='origin'):
     """Create a gerrit CL from the HEAD of a git checkout."""
     cls.check_call(
         ['git', 'push', remote, 'HEAD:refs/for/%s' % branch], cwd=clone_path)
 
-  def uploadChange(self, clone_path, branch='master', remote='origin'):
+  def uploadChange(self, clone_path, branch='main', remote='origin'):
     """Create a gerrit CL from the HEAD of a git checkout."""
     clone_path = os.path.join(self.tempdir, clone_path)
     self._UploadChange(clone_path, branch, remote)
 
   @classmethod
-  def _PushBranch(cls, clone_path, branch='master'):
+  def _PushBranch(cls, clone_path, branch='main'):
     """Push a branch directly to gerrit, bypassing code review."""
     cls.check_call(
         ['git', 'push', 'origin', 'HEAD:refs/heads/%s' % branch],
         cwd=clone_path)
 
-  def pushBranch(self, clone_path, branch='master'):
+  def pushBranch(self, clone_path, branch='main'):
     """Push a branch directly to gerrit, bypassing code review."""
     clone_path = os.path.join(self.tempdir, clone_path)
     self._PushBranch(clone_path, branch)
@@ -387,7 +387,7 @@ class RepoTestCase(GerritTestCase):
   <remote name="remote2"
           fetch="%(gerrit_url)s"
           review="%(gerrit_host)s" />
-  <default revision="refs/heads/master" remote="remote1" sync-j="1" />
+  <default revision="refs/heads/main" remote="remote1" sync-j="1" />
   <project remote="remote1" path="localpath/testproj1" name="remotepath/testproj1" />
   <project remote="remote1" path="localpath/testproj2" name="remotepath/testproj2" />
   <project remote="remote2" path="localpath/testproj3" name="remotepath/testproj3" />
@@ -431,7 +431,7 @@ class RepoTestCase(GerritTestCase):
       clone_path = os.path.join(gi.gerrit_dir, 'tmp', proj)
       cls._CloneProject('remotepath/%s' % proj, clone_path)
       cls._CreateCommit(clone_path)
-      cls._PushBranch(clone_path, 'master')
+      cls._PushBranch(clone_path, 'main')
 
   def setUp(self):
     super(RepoTestCase, self).setUp()
@@ -464,7 +464,7 @@ class RepoTestCase(GerritTestCase):
     args[0].insert(0, cls.repo_exe)
     cls.check_call(*args, **kwargs)
 
-  def uploadChange(self, clone_path, branch='master', remote='origin'):
+  def uploadChange(self, clone_path, branch='main', remote='origin'):
     review_host = self.check_output(
         ['git', 'config', 'remote.%s.review' % remote],
         cwd=clone_path).strip()

--- a/testing_support/git_test_utils.py
+++ b/testing_support/git_test_utils.py
@@ -128,7 +128,7 @@ class GitRepoSchema(object):
 
   Every commit gets a tag 'tag_%(commit)s'
   Every unique terminal commit gets a branch 'branch_%(commit)s'
-  Last commit in First line is the branch 'master'
+  Last commit in First line is the branch 'main'
   Root commits get a ref 'root_%(commit)s'
 
   Timestamps are in topo order, earlier commits (as indicated by their presence
@@ -150,7 +150,7 @@ class GitRepoSchema(object):
         commit_name). See the docstring on the GitRepo class for the format of
         the data returned by this function.
     """
-    self.master = None
+    self.main = None
     self.par_map = {}
     self.data_cache = {}
     self.content_fn = content_fn
@@ -197,8 +197,8 @@ class GitRepoSchema(object):
       for commit in commits:
         self.add_partial(commit, parent)
         parent = commit
-      if parent and not self.master:
-        self.master = parent
+      if parent and not self.main:
+        self.main = parent
     for _ in self.walk():  # This will throw if there are any cycles.
       pass
 
@@ -295,8 +295,8 @@ class GitRepo(object):
     for commit in schema.walk():
       self._add_schema_commit(commit, schema.data_for(commit.name))
       self.last_commit = self[commit.name]
-    if schema.master:
-      self.git('update-ref', 'refs/heads/master', self[schema.master])
+    if schema.main:
+      self.git('update-ref', 'refs/heads/main', self[schema.main])
 
   def __getitem__(self, commit_name):
     """Gets the hash of a commit by its schema name.

--- a/testing_support/patches_data.py
+++ b/testing_support/patches_data.py
@@ -84,7 +84,7 @@ class RAW(object):
   # http://codereview.chromium.org/api/7530007/5001
   # http://codereview.chromium.org/download/issue7530007_5001_4011.diff
   CRAP_ONLY = (
-      'Index: scripts/master/factory/skia/__init__.py\n'
+      'Index: scripts/main/factory/skia/__init__.py\n'
       '===================================================================\n')
 
   TWO_HUNKS = (
@@ -115,10 +115,10 @@ class RAW(object):
 
   # http://codereview.chromium.org/download/issue9091003_9005_8009.diff
   DIFFERENT = (
-      'Index: master/unittests/data/processes-summary.dat\n'
+      'Index: main/unittests/data/processes-summary.dat\n'
       '===================================================================\n'
-      '--- master/unittests/data/processes-summary.dat\t(revision 116240)\n'
-      '+++ master/unittests/data/processes-summary.dat\t(working copy)\n'
+      '--- main/unittests/data/processes-summary.dat\t(revision 116240)\n'
+      '+++ main/unittests/data/processes-summary.dat\t(working copy)\n'
       '@@ -1 +1 @@\n'
       '-{"traces": {"1t_proc": ["2.0", "0.0"], "1t_proc_ref": ["1.0", ...\n'
       '+{"traces": {"1t_proc": ["2.0", "0.0"], "1t_proc_ref": ["1.0", ...\n')

--- a/tests/bot_update_coverage_test.py
+++ b/tests/bot_update_coverage_test.py
@@ -174,7 +174,7 @@ class BotUpdateUnittests(unittest.TestCase):
     setattr(bot_update, 'git', fake_git)
 
     self.old_os_cwd = os.getcwd
-    setattr(os, 'getcwd', lambda: '/b/build/slave/foo/build')
+    setattr(os, 'getcwd', lambda: '/b/build/subordinate/foo/build')
 
     setattr(bot_update, 'open', self.filesystem.open)
     self.old_codecs_open = codecs.open

--- a/tests/checkout_test.py
+++ b/tests/checkout_test.py
@@ -233,7 +233,7 @@ class GitBaseTest(BaseTest):
     # Hackish to verify _branches() internal function.
     # pylint: disable=W0212
     self.assertEquals(
-        (['master', 'working_branch'], 'working_branch'),
+        (['main', 'working_branch'], 'working_branch'),
         co._branches())
 
     # Verify that the patch is applied even for read only checkout.
@@ -284,7 +284,7 @@ class GitCheckout(GitBaseTest):
     return checkout.GitCheckout(
       root_dir=self.root_dir,
       project_name=self.name,
-      remote_branch='master',
+      remote_branch='main',
       git_url=os.path.join(self.FAKE_REPOS.git_root,
                            self.FAKE_REPOS.TEST_GIT_REPO),
       commit_user=self.usr,

--- a/tests/gclient_scm_test.py
+++ b/tests/gclient_scm_test.py
@@ -147,8 +147,8 @@ mark :2
 data 4
 Bye
 
-reset refs/heads/master
-commit refs/heads/master
+reset refs/heads/main
+commit refs/heads/main
 mark :3
 author Bob <bob@example.com> 1253744361 -0700
 committer Bob <bob@example.com> 1253744361 -0700
@@ -193,7 +193,7 @@ Add C
 from :3
 M 100644 :7 c
 
-reset refs/heads/master
+reset refs/heads/main
 from :3
 """
   def Options(self, *args, **kwargs):
@@ -220,9 +220,9 @@ from :3
         cwd=path).communicate()
     Popen(['git', 'remote', 'add', '-f', 'origin', '.'], stdout=PIPE,
         stderr=STDOUT, cwd=path).communicate()
-    Popen(['git', 'checkout', '-b', 'new', 'origin/master', '-q'], stdout=PIPE,
+    Popen(['git', 'checkout', '-b', 'new', 'origin/main', '-q'], stdout=PIPE,
         stderr=STDOUT, cwd=path).communicate()
-    Popen(['git', 'push', 'origin', 'origin/origin:origin/master', '-q'],
+    Popen(['git', 'push', 'origin', 'origin/origin:origin/main', '-q'],
         stdout=PIPE, stderr=STDOUT, cwd=path).communicate()
     Popen(['git', 'config', '--unset', 'remote.origin.fetch'], stdout=PIPE,
         stderr=STDOUT, cwd=path).communicate()
@@ -414,7 +414,7 @@ class ManagedGitWrapperTestCase(BaseGitWrapperTestCase):
                       'd2e35c10ac24d6c621e14a1fcadceb533155627d')
     self.assertEquals(scm._Capture(['rev-parse', 'HEAD^1']), rev)
     self.assertEquals(scm._Capture(['rev-parse', 'HEAD^2']),
-                      scm._Capture(['rev-parse', 'origin/master']))
+                      scm._Capture(['rev-parse', 'origin/main']))
     sys.stdout.close()
 
   def testUpdateRebase(self):
@@ -437,7 +437,7 @@ class ManagedGitWrapperTestCase(BaseGitWrapperTestCase):
     self.assertEquals(scm._Capture(['rev-parse', 'HEAD:']),
                       'd2e35c10ac24d6c621e14a1fcadceb533155627d')
     self.assertEquals(scm._Capture(['rev-parse', 'HEAD^']),
-                      scm._Capture(['rev-parse', 'origin/master']))
+                      scm._Capture(['rev-parse', 'origin/main']))
     sys.stdout.close()
 
   def testUpdateReset(self):
@@ -549,7 +549,7 @@ class ManagedGitWrapperTestCase(BaseGitWrapperTestCase):
                  'Fix the conflict and run gclient again.\n'
                  'See \'man git-rebase\' for details.\n')
     self.assertRaisesError(exception, scm.update, options, (), [])
-    exception = ('\n____ . at refs/remotes/origin/master\n'
+    exception = ('\n____ . at refs/remotes/origin/main\n'
                  '\tYou have unstaged changes.\n'
                  '\tPlease commit, stash, or reset.\n')
     self.assertRaisesError(exception, scm.update, options, (), [])
@@ -713,7 +713,7 @@ class ManagedGitWrapperTestCaseMox(BaseTestCase):
                                ).AndReturn(False)
     self.mox.StubOutWithMock(gclient_scm.GitWrapper, '_Clone', True)
     # pylint: disable=E1120
-    gclient_scm.GitWrapper._Clone('refs/remotes/origin/master', self.url,
+    gclient_scm.GitWrapper._Clone('refs/remotes/origin/main', self.url,
                                   options)
     self.mox.StubOutWithMock(gclient_scm.subprocess2, 'check_output', True)
     gclient_scm.subprocess2.check_output(
@@ -745,12 +745,12 @@ class ManagedGitWrapperTestCaseMox(BaseTestCase):
     self.mox.StubOutWithMock(gclient_scm.GitWrapper, '_Clone', True)
     # pylint: disable=E1120
     gclient_scm.GitWrapper._Clone(
-        'refs/remotes/origin/master', self.url, options
+        'refs/remotes/origin/main', self.url, options
     ).AndRaise(gclient_scm.subprocess2.CalledProcessError(None, None, None,
                                                           None, None))
     self.mox.StubOutWithMock(gclient_scm.GitWrapper, '_DeleteOrMove', True)
     gclient_scm.GitWrapper._DeleteOrMove(False)
-    gclient_scm.GitWrapper._Clone('refs/remotes/origin/master', self.url,
+    gclient_scm.GitWrapper._Clone('refs/remotes/origin/main', self.url,
                                   options)
     self.mox.StubOutWithMock(gclient_scm.subprocess2, 'check_output', True)
     gclient_scm.subprocess2.check_output(
@@ -817,7 +817,7 @@ class UnmanagedGitWrapperTestCase(BaseGitWrapperTestCase):
     # indicates detached HEAD
     self.assertEquals(self.getCurrentBranch(), None)
     self.checkInStdout(
-      'Checked out refs/remotes/origin/master to a detached HEAD')
+      'Checked out refs/remotes/origin/main to a detached HEAD')
 
     rmtree(origin_root_dir)
 

--- a/tests/git_cache_test.py
+++ b/tests/git_cache_test.py
@@ -30,12 +30,12 @@ class GitCacheTest(unittest.TestCase):
   def testParseFetchSpec(self):
     testData = [
         ([], []),
-        (['master'], [('+refs/heads/master:refs/heads/master',
-                       r'\+refs/heads/master:.*')]),
-        (['master/'], [('+refs/heads/master:refs/heads/master',
-                       r'\+refs/heads/master:.*')]),
-        (['+master'], [('+refs/heads/master:refs/heads/master',
-                       r'\+refs/heads/master:.*')]),
+        (['main'], [('+refs/heads/main:refs/heads/main',
+                       r'\+refs/heads/main:.*')]),
+        (['main/'], [('+refs/heads/main:refs/heads/main',
+                       r'\+refs/heads/main:.*')]),
+        (['+main'], [('+refs/heads/main:refs/heads/main',
+                       r'\+refs/heads/main:.*')]),
         (['refs/heads/*'], [('+refs/heads/*:refs/heads/*',
                             r'\+refs/heads/\*:.*')]),
         (['foo/bar/*', 'baz'], [('+refs/heads/foo/bar/*:refs/heads/foo/bar/*',

--- a/tests/git_cl_test.py
+++ b/tests/git_cl_test.py
@@ -341,19 +341,19 @@ class TestGitCl(TestCase):
     if similarity is None:
       similarity = '50'
       similarity_call = ((['git', 'config',
-                         'branch.master.git-cl-similarity'],), CERR1)
+                         'branch.main.git-cl-similarity'],), CERR1)
     else:
       similarity_call = ((['git', 'config',
-                           'branch.master.git-cl-similarity', similarity],), '')
+                           'branch.main.git-cl-similarity', similarity],), '')
 
     if find_copies is None:
       find_copies = True
       find_copies_call = ((['git', 'config', '--bool',
-                          'branch.master.git-find-copies'],), CERR1)
+                          'branch.main.git-find-copies'],), CERR1)
     else:
       val = str(find_copies).lower()
       find_copies_call = ((['git', 'config', '--bool',
-                          'branch.master.git-find-copies', val],), '')
+                          'branch.main.git-find-copies', val],), '')
 
     if find_copies:
       stat_call = ((['git', 'diff', '--no-ext-diff', '--stat',
@@ -364,27 +364,27 @@ class TestGitCl(TestCase):
                    '-M'+similarity, 'fake_ancestor_sha', 'HEAD'],), '+dat')
 
     return [
-      ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
+      ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
       similarity_call,
-      ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
+      ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
       find_copies_call,
     ] + cls._is_gerrit_calls() + [
-      ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
-      ((['git', 'config', 'branch.master.rietveldissue'],), CERR1),
-      ((['git', 'config', 'branch.master.gerritissue'],), CERR1),
+      ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
+      ((['git', 'config', 'branch.main.rietveldissue'],), CERR1),
+      ((['git', 'config', 'branch.main.gerritissue'],), CERR1),
       ((['git', 'config', 'rietveld.server'],),
        'codereview.example.com'),
-      ((['git', 'config', 'branch.master.merge'],), 'master'),
-      ((['git', 'config', 'branch.master.remote'],), 'origin'),
-      ((['get_or_create_merge_base', 'master', 'master'],),
+      ((['git', 'config', 'branch.main.merge'],), 'main'),
+      ((['git', 'config', 'branch.main.remote'],), 'origin'),
+      ((['get_or_create_merge_base', 'main', 'main'],),
        'fake_ancestor_sha'),
-    ] + cls._git_sanity_checks('fake_ancestor_sha', 'master') + [
+    ] + cls._git_sanity_checks('fake_ancestor_sha', 'main') + [
       ((['git', 'rev-parse', '--show-cdup'],), ''),
       ((['git', 'rev-parse', 'HEAD'],), '12345'),
       ((['git', 'diff', '--name-status', '--no-renames', '-r',
          'fake_ancestor_sha...', '.'],),
         'M\t.gitignore\n'),
-      ((['git', 'config', 'branch.master.rietveldpatchset'],), CERR1),
+      ((['git', 'config', 'branch.main.rietveldpatchset'],), CERR1),
       ((['git', 'log', '--pretty=format:%s%n%n%b',
          'fake_ancestor_sha...'],),
        'foo'),
@@ -415,7 +415,7 @@ class TestGitCl(TestCase):
     return [
         ((['git', 'config', 'core.editor'],), ''),
     ] + cc_call + private_call + [
-        ((['git', 'config', 'branch.master.base-url'],), ''),
+        ((['git', 'config', 'branch.main.base-url'],), ''),
         ((['git', 'config', 'rietveld.pending-ref-prefix'],), ''),
         ((['git',
            'config', '--local', '--get-regexp', '^svn-remote\\.'],),
@@ -423,11 +423,11 @@ class TestGitCl(TestCase):
         ((['git', 'rev-parse', '--show-cdup'],), ''),
         ((['git', 'svn', 'info'],), ''),
         ((['git', 'config', 'rietveld.project'],), ''),
-        ((['git', 'config', 'branch.master.rietveldissue', '1'],), ''),
-        ((['git', 'config', 'branch.master.rietveldserver',
+        ((['git', 'config', 'branch.main.rietveldissue', '1'],), ''),
+        ((['git', 'config', 'branch.main.rietveldserver',
            'https://codereview.example.com'],), ''),
         ((['git',
-           'config', 'branch.master.rietveldpatchset', '2'],), ''),
+           'config', 'branch.main.rietveldpatchset', '2'],), ''),
     ] + cls._git_post_upload_calls()
 
   @classmethod
@@ -458,12 +458,12 @@ class TestGitCl(TestCase):
       # Call to GetRemoteBranch()
       ((['git',
          'config', 'branch.%s.merge' % working_branch],),
-       'refs/heads/master'),
+       'refs/heads/main'),
       ((['git',
          'config', 'branch.%s.remote' % working_branch],), 'origin'),
     ] if get_remote_branch else []) + [
       ((['git', 'rev-list', '^' + fake_ancestor,
-         'refs/remotes/origin/master'],), ''),
+         'refs/remotes/origin/main'],), ''),
     ]
 
   @classmethod
@@ -476,7 +476,7 @@ class TestGitCl(TestCase):
       ((['git',
          'config', '--local', '--get-regexp', '^svn-remote\\.'],),
        ((('svn-remote.svn.url svn://svn.chromium.org/chrome\n'
-          'svn-remote.svn.fetch trunk/src:refs/remotes/origin/master'),
+          'svn-remote.svn.fetch trunk/src:refs/remotes/origin/main'),
          None),
         0)),
       ((['git', 'symbolic-ref', 'HEAD'],), 'refs/heads/working'),
@@ -491,25 +491,25 @@ class TestGitCl(TestCase):
       ((['git',
          'config', 'rietveld.server'],), 'codereview.example.com'),
       ((['git',
-         'config', 'branch.working.merge'],), 'refs/heads/master'),
+         'config', 'branch.working.merge'],), 'refs/heads/main'),
       ((['git', 'config', 'branch.working.remote'],), 'origin'),
       ((['git', 'config', 'branch.working.merge'],),
-       'refs/heads/master'),
+       'refs/heads/main'),
       ((['git', 'config', 'branch.working.remote'],), 'origin'),
       ((['git', 'rev-list', '--merges',
          '--grep=^SVN changes up to revision [0-9]*$',
-         'refs/remotes/origin/master^!'],), ''),
+         'refs/remotes/origin/main^!'],), ''),
       ((['git', 'rev-list', '^refs/heads/working',
-         'refs/remotes/origin/master'],),
+         'refs/remotes/origin/main'],),
          ''),
       ((['git',
          'log', '--grep=^git-svn-id:', '-1', '--pretty=format:%H'],),
          '3fc18b62c4966193eb435baabe2d18a3810ec82e'),
       ((['git',
          'rev-list', '^3fc18b62c4966193eb435baabe2d18a3810ec82e',
-         'refs/remotes/origin/master'],), ''),
+         'refs/remotes/origin/main'],), ''),
       ((['git',
-         'merge-base', 'refs/remotes/origin/master', 'HEAD'],),
+         'merge-base', 'refs/remotes/origin/main', 'HEAD'],),
        'fake_ancestor_sha'),
     ]
 
@@ -759,11 +759,11 @@ class TestGitCl(TestCase):
     calls = [((cmd, ), CERR1)]
     if issue:
       calls.extend([
-          ((['git', 'config', 'branch.master.gerritserver'],), ''),
+          ((['git', 'config', 'branch.main.gerritserver'],), ''),
       ])
     calls.extend([
-        ((['git', 'config', 'branch.master.merge'],), 'refs/heads/master'),
-        ((['git', 'config', 'branch.master.remote'],), 'origin'),
+        ((['git', 'config', 'branch.main.merge'],), 'refs/heads/main'),
+        ((['git', 'config', 'branch.main.remote'],), 'origin'),
         ((['git', 'config', 'remote.origin.url'],),
          'https://chromium.googlesource.com/my/repo'),
         ((['git', 'config', 'remote.origin.url'],),
@@ -774,25 +774,25 @@ class TestGitCl(TestCase):
   @classmethod
   def _gerrit_base_calls(cls, issue=None):
     return [
-        ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
-        ((['git', 'config', 'branch.master.git-cl-similarity'],),
+        ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
+        ((['git', 'config', 'branch.main.git-cl-similarity'],),
          CERR1),
-        ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
-        ((['git', 'config', '--bool', 'branch.master.git-find-copies'],),
+        ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
+        ((['git', 'config', '--bool', 'branch.main.git-find-copies'],),
          CERR1),
       ] + cls._is_gerrit_calls(True) + [
-        ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
-        ((['git', 'config', 'branch.master.rietveldissue'],), CERR1),
-        ((['git', 'config', 'branch.master.gerritissue'],),
+        ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
+        ((['git', 'config', 'branch.main.rietveldissue'],), CERR1),
+        ((['git', 'config', 'branch.main.gerritissue'],),
           CERR1 if issue is None else str(issue)),
-        ((['git', 'config', 'branch.master.merge'],), 'refs/heads/master'),
-        ((['git', 'config', 'branch.master.remote'],), 'origin'),
-        ((['get_or_create_merge_base', 'master',
-           'refs/remotes/origin/master'],),
+        ((['git', 'config', 'branch.main.merge'],), 'refs/heads/main'),
+        ((['git', 'config', 'branch.main.remote'],), 'origin'),
+        ((['get_or_create_merge_base', 'main',
+           'refs/remotes/origin/main'],),
          'fake_ancestor_sha'),
         # Calls to verify branch point is ancestor
       ] + (cls._gerrit_ensure_auth_calls(issue=issue) +
-           cls._git_sanity_checks('fake_ancestor_sha', 'master',
+           cls._git_sanity_checks('fake_ancestor_sha', 'main',
                                   get_remote_branch=False)) + [
         ((['git', 'rev-parse', '--show-cdup'],), ''),
         ((['git', 'rev-parse', 'HEAD'],), '12345'),
@@ -801,7 +801,7 @@ class TestGitCl(TestCase):
            'diff', '--name-status', '--no-renames', '-r',
            'fake_ancestor_sha...', '.'],),
          'M\t.gitignore\n'),
-        ((['git', 'config', 'branch.master.gerritpatchset'],), CERR1),
+        ((['git', 'config', 'branch.main.gerritpatchset'],), CERR1),
       ] + ([] if issue else [
         ((['git',
            'log', '--pretty=format:%s%n%n%b', 'fake_ancestor_sha...'],),
@@ -817,7 +817,7 @@ class TestGitCl(TestCase):
   @classmethod
   def _gerrit_upload_calls(cls, description, reviewers, squash,
                            squash_mode='default',
-                           expected_upstream_ref='origin/refs/heads/master',
+                           expected_upstream_ref='origin/refs/heads/main',
                            ref_suffix='', notify=False,
                            post_amend_description=None, issue=None):
     if post_amend_description is None:
@@ -867,17 +867,17 @@ class TestGitCl(TestCase):
         ]
       ref_to_push = 'abcdef0123456789'
       calls += [
-          ((['git', 'config', 'branch.master.merge'],),
-           'refs/heads/master'),
-          ((['git', 'config', 'branch.master.remote'],),
+          ((['git', 'config', 'branch.main.merge'],),
+           'refs/heads/main'),
+          ((['git', 'config', 'branch.main.remote'],),
            'origin'),
-          ((['get_or_create_merge_base', 'master',
-             'refs/remotes/origin/master'],),
-           'origin/master'),
+          ((['get_or_create_merge_base', 'main',
+             'refs/remotes/origin/main'],),
+           'origin/main'),
           ((['git', 'rev-parse', 'HEAD:'],),
            '0123456789abcdef'),
           ((['git', 'commit-tree', '0123456789abcdef', '-p',
-             'origin/master', '-m', description],),
+             'origin/main', '-m', description],),
            ref_to_push),
           ]
     else:
@@ -899,7 +899,7 @@ class TestGitCl(TestCase):
                                    for email in sorted(reviewers))
     calls += [
         ((['git', 'push', 'origin',
-           ref_to_push + ':refs/for/refs/heads/master' + ref_suffix],),
+           ref_to_push + ':refs/for/refs/heads/main' + ref_suffix],),
          ('remote:\n'
          'remote: Processing changes: (\)\n'
          'remote: Processing changes: (|)\n'
@@ -912,15 +912,15 @@ class TestGitCl(TestCase):
          'remote:   https://chromium-review.googlesource.com/123456 XXX.\n'
          'remote:\n'
          'To https://chromium.googlesource.com/yyy/zzz\n'
-         ' * [new branch]      hhhh -> refs/for/refs/heads/master\n')),
+         ' * [new branch]      hhhh -> refs/for/refs/heads/main\n')),
         ]
     if squash:
       calls += [
-          ((['git', 'config', 'branch.master.gerritissue', '123456'],),
+          ((['git', 'config', 'branch.main.gerritissue', '123456'],),
            ''),
-          ((['git', 'config', 'branch.master.gerritserver',
+          ((['git', 'config', 'branch.main.gerritserver',
              'https://chromium-review.googlesource.com'],), ''),
-          ((['git', 'config', 'branch.master.gerritsquashhash',
+          ((['git', 'config', 'branch.main.gerritsquashhash',
              'abcdef0123456789'],), ''),
       ]
     calls += [
@@ -939,7 +939,7 @@ class TestGitCl(TestCase):
       reviewers=None,
       squash=True,
       squash_mode=None,
-      expected_upstream_ref='origin/refs/heads/master',
+      expected_upstream_ref='origin/refs/heads/main',
       ref_suffix='',
       notify=False,
       post_amend_description=None,
@@ -1044,7 +1044,7 @@ class TestGitCl(TestCase):
         [],
         'desc\nBUG=\n\nChange-Id: 123456789',
         [],
-        expected_upstream_ref='origin/master')
+        expected_upstream_ref='origin/main')
 
   def test_gerrit_upload_squash_first(self):
     # Mock Gerrit CL description to indicate the first upload.
@@ -1055,7 +1055,7 @@ class TestGitCl(TestCase):
         'desc\nBUG=\n\nChange-Id: 123456789',
         [],
         squash=True,
-        expected_upstream_ref='origin/master')
+        expected_upstream_ref='origin/main')
 
   def test_gerrit_upload_squash_reupload(self):
     description = 'desc\nBUG=\n\nChange-Id: 123456789'
@@ -1071,7 +1071,7 @@ class TestGitCl(TestCase):
         description,
         [],
         squash=True,
-        expected_upstream_ref='origin/master',
+        expected_upstream_ref='origin/main',
         issue=123456)
 
   def test_upload_branch_deps(self):
@@ -1192,19 +1192,19 @@ class TestGitCl(TestCase):
 
   def test_get_target_ref(self):
     # Check remote or remote branch not present.
-    self.assertEqual(None, git_cl.GetTargetRef('origin', None, 'master', None))
+    self.assertEqual(None, git_cl.GetTargetRef('origin', None, 'main', None))
     self.assertEqual(None, git_cl.GetTargetRef(None,
-                                               'refs/remotes/origin/master',
-                                               'master', None))
+                                               'refs/remotes/origin/main',
+                                               'main', None))
 
     # Check default target refs for branches.
-    self.assertEqual('refs/heads/master',
-                     git_cl.GetTargetRef('origin', 'refs/remotes/origin/master',
+    self.assertEqual('refs/heads/main',
+                     git_cl.GetTargetRef('origin', 'refs/remotes/origin/main',
                                          None, None))
-    self.assertEqual('refs/heads/master',
+    self.assertEqual('refs/heads/main',
                      git_cl.GetTargetRef('origin', 'refs/remotes/origin/lkgr',
                                          None, None))
-    self.assertEqual('refs/heads/master',
+    self.assertEqual('refs/heads/main',
                      git_cl.GetTargetRef('origin', 'refs/remotes/origin/lkcr',
                                          None, None))
     self.assertEqual('refs/branch-heads/123',
@@ -1225,23 +1225,23 @@ class TestGitCl(TestCase):
                    'refs/remotes/branch-heads/123'):
       self.assertEqual('refs/branch-heads/123',
                        git_cl.GetTargetRef('origin',
-                                           'refs/remotes/origin/master',
+                                           'refs/remotes/origin/main',
                                            branch, None))
-    for branch in ('origin/master', 'remotes/origin/master',
-                   'refs/remotes/origin/master'):
-      self.assertEqual('refs/heads/master',
+    for branch in ('origin/main', 'remotes/origin/main',
+                   'refs/remotes/origin/main'):
+      self.assertEqual('refs/heads/main',
                        git_cl.GetTargetRef('origin',
                                            'refs/remotes/branch-heads/123',
                                            branch, None))
-    for branch in ('master', 'heads/master', 'refs/heads/master'):
-      self.assertEqual('refs/heads/master',
+    for branch in ('main', 'heads/main', 'refs/heads/main'):
+      self.assertEqual('refs/heads/main',
                        git_cl.GetTargetRef('origin',
                                            'refs/remotes/branch-heads/123',
                                            branch, None))
 
     # Check target refs for pending prefix.
-    self.assertEqual('prefix/heads/master',
-                     git_cl.GetTargetRef('origin', 'refs/remotes/origin/master',
+    self.assertEqual('prefix/heads/main',
+                     git_cl.GetTargetRef('origin', 'refs/remotes/origin/main',
                                          None, 'prefix/'))
 
   def test_patch_when_dirty(self):
@@ -1286,15 +1286,15 @@ class TestGitCl(TestCase):
     self.mock(git_cl, 'IsGitVersionAtLeast', lambda *args: True)
 
     if new_branch:
-      self.calls = [((['git', 'new-branch', 'master'],), ''),]
+      self.calls = [((['git', 'new-branch', 'main'],), ''),]
     else:
-      self.calls = [((['git', 'symbolic-ref', 'HEAD'],), 'master')]
+      self.calls = [((['git', 'symbolic-ref', 'HEAD'],), 'main')]
     if not force_codereview:
       # These calls detect codereview to use.
       self.calls += [
-        ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
-        ((['git', 'config', 'branch.master.rietveldissue'],), CERR1),
-        ((['git', 'config', 'branch.master.gerritissue'],), CERR1),
+        ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
+        ((['git', 'config', 'branch.main.rietveldissue'],), CERR1),
+        ((['git', 'config', 'branch.main.gerritissue'],), CERR1),
         ((['git', 'config', 'rietveld.autoupdate'],), CERR1),
       ]
 
@@ -1319,12 +1319,12 @@ class TestGitCl(TestCase):
          'Description\n\n' +
          'patch from issue 123456 at patchset 60001 ' +
          '(http://crrev.com/123456#ps60001)'],), ''),
-      ((['git', 'config', 'branch.master.rietveldissue', '123456'],),
+      ((['git', 'config', 'branch.main.rietveldissue', '123456'],),
        ''),
-      ((['git', 'config', 'branch.master.rietveldserver'],), CERR1),
-      ((['git', 'config', 'branch.master.rietveldserver',
+      ((['git', 'config', 'branch.main.rietveldserver'],), CERR1),
+      ((['git', 'config', 'branch.main.rietveldserver',
          'https://codereview.example.com'],), ''),
-      ((['git', 'config', 'branch.master.rietveldpatchset', '60001'],),
+      ((['git', 'config', 'branch.main.rietveldpatchset', '60001'],),
        ''),
     ]
 
@@ -1334,7 +1334,7 @@ class TestGitCl(TestCase):
 
   def test_patch_successful_new_branch(self):
     self._common_patch_successful(new_branch=True)
-    self.assertEqual(git_cl.main(['patch', '-b', 'master', '123456']), 0)
+    self.assertEqual(git_cl.main(['patch', '-b', 'main', '123456']), 0)
 
   def test_patch_conflict(self):
     self._patch_common()
@@ -1349,16 +1349,16 @@ class TestGitCl(TestCase):
       ((['git', 'fetch', 'https://chromium.googlesource.com/my/repo',
          'refs/changes/56/123456/7'],), ''),
       ((['git', 'cherry-pick', 'FETCH_HEAD'],), ''),
-      ((['git', 'config', 'branch.master.gerritissue', '123456'],),
+      ((['git', 'config', 'branch.main.gerritissue', '123456'],),
        ''),
-      ((['git', 'config', 'branch.master.gerritserver'],), ''),
-      ((['git', 'config', 'branch.master.merge'],), 'master'),
-      ((['git', 'config', 'branch.master.remote'],), 'origin'),
+      ((['git', 'config', 'branch.main.gerritserver'],), ''),
+      ((['git', 'config', 'branch.main.merge'],), 'main'),
+      ((['git', 'config', 'branch.main.remote'],), 'origin'),
       ((['git', 'config', 'remote.origin.url'],),
        'https://chromium.googlesource.com/my/repo'),
-      ((['git', 'config', 'branch.master.gerritserver',
+      ((['git', 'config', 'branch.main.gerritserver',
         'https://chromium-review.googlesource.com'],), ''),
-      ((['git', 'config', 'branch.master.gerritpatchset', '7'],), ''),
+      ((['git', 'config', 'branch.main.gerritpatchset', '7'],), ''),
     ]
     self.assertEqual(git_cl.main(['patch', '123456']), 0)
 
@@ -1368,17 +1368,17 @@ class TestGitCl(TestCase):
       ((['git', 'fetch', 'https://chromium.googlesource.com/my/repo',
          'refs/changes/56/123456/7'],), ''),
       ((['git', 'cherry-pick', 'FETCH_HEAD'],), ''),
-      ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
-      ((['git', 'config', 'branch.master.gerritissue', '123456'],),
+      ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
+      ((['git', 'config', 'branch.main.gerritissue', '123456'],),
        ''),
-      ((['git', 'config', 'branch.master.gerritserver'],), ''),
-      ((['git', 'config', 'branch.master.merge'],), 'master'),
-      ((['git', 'config', 'branch.master.remote'],), 'origin'),
+      ((['git', 'config', 'branch.main.gerritserver'],), ''),
+      ((['git', 'config', 'branch.main.merge'],), 'main'),
+      ((['git', 'config', 'branch.main.remote'],), 'origin'),
       ((['git', 'config', 'remote.origin.url'],),
        'https://chromium.googlesource.com/my/repo'),
-      ((['git', 'config', 'branch.master.gerritserver',
+      ((['git', 'config', 'branch.main.gerritserver',
         'https://chromium-review.googlesource.com'],), ''),
-      ((['git', 'config', 'branch.master.gerritpatchset', '7'],), ''),
+      ((['git', 'config', 'branch.main.gerritpatchset', '7'],), ''),
     ]
     self.assertEqual(git_cl.main(['patch', '--gerrit', '123456']), 0)
 
@@ -1388,11 +1388,11 @@ class TestGitCl(TestCase):
       ((['git', 'fetch', 'https://chromium.googlesource.com/my/repo',
          'refs/changes/56/123456/1'],), ''),
       ((['git', 'cherry-pick', 'FETCH_HEAD'],), ''),
-      ((['git', 'config', 'branch.master.gerritissue', '123456'],),
+      ((['git', 'config', 'branch.main.gerritissue', '123456'],),
        ''),
-      ((['git', 'config', 'branch.master.gerritserver',
+      ((['git', 'config', 'branch.main.gerritserver',
         'https://chromium-review.googlesource.com'],), ''),
-      ((['git', 'config', 'branch.master.gerritpatchset', '1'],), ''),
+      ((['git', 'config', 'branch.main.gerritpatchset', '1'],), ''),
     ]
     self.assertEqual(git_cl.main(
       ['patch', 'https://chromium-review.googlesource.com/#/c/123456/1']), 0)
@@ -1465,8 +1465,8 @@ class TestGitCl(TestCase):
               lambda msg: self._mocked_call(['ask_for_data', msg]))
     self.calls = self._gerrit_ensure_auth_calls(skip_auth_check=skip_auth_check)
     cl = git_cl.Changelist(codereview='gerrit')
-    cl.branch = 'master'
-    cl.branchref = 'refs/heads/master'
+    cl.branch = 'main'
+    cl.branchref = 'refs/heads/main'
     cl.lookedup_issue = True
     return cl
 
@@ -1705,20 +1705,20 @@ class TestGitCl(TestCase):
 
     self.calls = \
         [((['git', 'for-each-ref', '--format=%(refname)', 'refs/heads'],),
-          'refs/heads/master\nrefs/heads/foo\nrefs/heads/bar'),
-         ((['git', 'config', 'branch.master.rietveldissue'],), '1'),
+          'refs/heads/main\nrefs/heads/foo\nrefs/heads/bar'),
+         ((['git', 'config', 'branch.main.rietveldissue'],), '1'),
          ((['git', 'config', 'rietveld.autoupdate'],), CERR1),
          ((['git', 'config', 'rietveld.server'],), 'codereview.example.com'),
          ((['git', 'config', 'branch.foo.rietveldissue'],), '456'),
          ((['git', 'config', 'branch.bar.rietveldissue'],), CERR1),
          ((['git', 'config', 'branch.bar.gerritissue'],), '789'),
-         ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
+         ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
          ((['git', 'tag', 'git-cl-archived-456-foo', 'foo'],), ''),
          ((['git', 'branch', '-D', 'foo'],), '')]
 
     self.mock(git_cl, 'get_cl_statuses',
               lambda branches, fine_grained, max_processes:
-              [(MockChangelistWithBranchAndIssue('master', 1), 'open'),
+              [(MockChangelistWithBranchAndIssue('main', 1), 'open'),
                (MockChangelistWithBranchAndIssue('foo', 456), 'closed'),
                (MockChangelistWithBranchAndIssue('bar', 789), 'open')])
 
@@ -1728,15 +1728,15 @@ class TestGitCl(TestCase):
     self.mock(git_cl.sys, 'stdout', StringIO.StringIO())
     self.calls = \
         [((['git', 'for-each-ref', '--format=%(refname)', 'refs/heads'],),
-          'refs/heads/master'),
-         ((['git', 'config', 'branch.master.rietveldissue'],), '1'),
+          'refs/heads/main'),
+         ((['git', 'config', 'branch.main.rietveldissue'],), '1'),
          ((['git', 'config', 'rietveld.autoupdate'],), CERR1),
          ((['git', 'config', 'rietveld.server'],), 'codereview.example.com'),
-         ((['git', 'symbolic-ref', 'HEAD'],), 'master')]
+         ((['git', 'symbolic-ref', 'HEAD'],), 'main')]
 
     self.mock(git_cl, 'get_cl_statuses',
               lambda branches, fine_grained, max_processes:
-              [(MockChangelistWithBranchAndIssue('master', 1), 'closed')])
+              [(MockChangelistWithBranchAndIssue('main', 1), 'closed')])
 
     self.assertEqual(1, git_cl.main(['archive', '-f']))
 
@@ -1745,18 +1745,18 @@ class TestGitCl(TestCase):
 
     self.calls = \
         [((['git', 'for-each-ref', '--format=%(refname)', 'refs/heads'],),
-          'refs/heads/master\nrefs/heads/foo\nrefs/heads/bar'),
-         ((['git', 'config', 'branch.master.rietveldissue'],), '1'),
+          'refs/heads/main\nrefs/heads/foo\nrefs/heads/bar'),
+         ((['git', 'config', 'branch.main.rietveldissue'],), '1'),
          ((['git', 'config', 'rietveld.autoupdate'],), CERR1),
          ((['git', 'config', 'rietveld.server'],), 'codereview.example.com'),
          ((['git', 'config', 'branch.foo.rietveldissue'],), '456'),
          ((['git', 'config', 'branch.bar.rietveldissue'],), CERR1),
          ((['git', 'config', 'branch.bar.gerritissue'],), '789'),
-         ((['git', 'symbolic-ref', 'HEAD'],), 'master'),]
+         ((['git', 'symbolic-ref', 'HEAD'],), 'main'),]
 
     self.mock(git_cl, 'get_cl_statuses',
               lambda branches, fine_grained, max_processes:
-              [(MockChangelistWithBranchAndIssue('master', 1), 'open'),
+              [(MockChangelistWithBranchAndIssue('main', 1), 'open'),
                (MockChangelistWithBranchAndIssue('foo', 456), 'closed'),
                (MockChangelistWithBranchAndIssue('bar', 789), 'open')])
 
@@ -1767,19 +1767,19 @@ class TestGitCl(TestCase):
 
     self.calls = \
         [((['git', 'for-each-ref', '--format=%(refname)', 'refs/heads'],),
-          'refs/heads/master\nrefs/heads/foo\nrefs/heads/bar'),
-         ((['git', 'config', 'branch.master.rietveldissue'],), '1'),
+          'refs/heads/main\nrefs/heads/foo\nrefs/heads/bar'),
+         ((['git', 'config', 'branch.main.rietveldissue'],), '1'),
          ((['git', 'config', 'rietveld.autoupdate'],), CERR1),
          ((['git', 'config', 'rietveld.server'],), 'codereview.example.com'),
          ((['git', 'config', 'branch.foo.rietveldissue'],), '456'),
          ((['git', 'config', 'branch.bar.rietveldissue'],), CERR1),
          ((['git', 'config', 'branch.bar.gerritissue'],), '789'),
-         ((['git', 'symbolic-ref', 'HEAD'],), 'master'),
+         ((['git', 'symbolic-ref', 'HEAD'],), 'main'),
          ((['git', 'branch', '-D', 'foo'],), '')]
 
     self.mock(git_cl, 'get_cl_statuses',
               lambda branches, fine_grained, max_processes:
-              [(MockChangelistWithBranchAndIssue('master', 1), 'open'),
+              [(MockChangelistWithBranchAndIssue('main', 1), 'open'),
                (MockChangelistWithBranchAndIssue('foo', 456), 'closed'),
                (MockChangelistWithBranchAndIssue('bar', 789), 'open')])
 
@@ -1823,12 +1823,12 @@ class TestGitCl(TestCase):
     self.mock(git_cl.Changelist, 'GetChange',
               lambda _, *a: (
                 self._mocked_call(['GetChange']+list(a))))
-    self.mock(git_cl.presubmit_support, 'DoGetTryMasters',
+    self.mock(git_cl.presubmit_support, 'DoGetTryMains',
               lambda *_, **__: (
-                self._mocked_call(['DoGetTryMasters'])))
-    self.mock(git_cl.presubmit_support, 'DoGetTrySlaves',
+                self._mocked_call(['DoGetTryMains'])))
+    self.mock(git_cl.presubmit_support, 'DoGetTrySubordinates',
               lambda *_, **__: (
-                self._mocked_call(['DoGetTrySlaves'])))
+                self._mocked_call(['DoGetTrySubordinates'])))
     self.mock(git_cl._RietveldChangelistImpl, 'SetCQState',
               lambda _, s: self._mocked_call(['SetCQState', s]))
     self.calls = [
@@ -1846,8 +1846,8 @@ class TestGitCl(TestCase):
          git_cl.presubmit_support.GitChange(
            '', '', '', '', '', '', '', '')),
         ((['git', 'rev-parse', '--show-cdup'],), '../'),
-        ((['DoGetTryMasters'], ), None),
-        ((['DoGetTrySlaves'], ), None),
+        ((['DoGetTryMains'], ), None),
+        ((['DoGetTrySubordinates'], ), None),
         ((['SetCQState', git_cl._CQState.DRY_RUN], ), None),
     ]
     out = StringIO.StringIO()
@@ -1927,7 +1927,7 @@ class TestGitCl(TestCase):
             'status': 'STARTED',
             'url': 'http://build.cr.org/p/x.y/builders/my-builder/builds/2',
             'result_details_json': '{"properties": {}}',
-            'bucket': 'master.x.y',
+            'bucket': 'main.x.y',
             'created_by': 'user:someone@chromium.org',
             'created_ts': '147200002222000',
             'parameters_json': '{"builder_name": "my-builder", "category": ""}',
@@ -1939,7 +1939,7 @@ class TestGitCl(TestCase):
             'failure_reason': 'BUILD_FAILURE',
             'url': 'http://build.cr.org/p/x.y/builders/my-builder/builds/1',
             'result_details_json': '{"properties": {}}',
-            'bucket': 'master.x.y',
+            'bucket': 'main.x.y',
             'created_by': 'user:someone@chromium.org',
             'created_ts': '147200001111000',
             'parameters_json': '{"builder_name": "my-builder", "category": ""}',
@@ -1950,7 +1950,7 @@ class TestGitCl(TestCase):
     expected_output = [
         {
             'buildbucket_id': '8000',
-            'bucket': 'master.x.y',
+            'bucket': 'main.x.y',
             'builder_name': 'my-builder',
             'status': 'COMPLETED',
             'result': 'FAILURE',
@@ -1959,7 +1959,7 @@ class TestGitCl(TestCase):
         },
         {
             'buildbucket_id': '9000',
-            'bucket': 'master.x.y',
+            'bucket': 'main.x.y',
             'builder_name': 'my-builder',
             'status': 'STARTED',
             'result': None,

--- a/tests/git_common_test.py
+++ b/tests/git_common_test.py
@@ -190,8 +190,8 @@ class GitReadOnlyFunctionsTest(git_test_utils.GitRepoReadOnlyTestBase,
   def testHashes(self):
     ret = self.repo.run(
       self.gc.hash_multi, *[
-        'master',
-        'master~3',
+        'main',
+        'main~3',
         self.repo['E']+'~',
         self.repo['D']+'^2',
         'tag_C^{}',
@@ -252,7 +252,7 @@ class GitReadOnlyFunctionsTest(git_test_utils.GitRepoReadOnlyTestBase,
   def testBranches(self):
     # This check fails with git 2.4 (see crbug.com/487172)
     self.assertEqual(self.repo.run(set, self.gc.branches()),
-                     {'master', 'branch_D', 'root_A'})
+                     {'main', 'branch_D', 'root_A'})
 
   def testDiff(self):
     # Get the names of the blobs being compared (to avoid hard-coding).
@@ -272,9 +272,9 @@ class GitReadOnlyFunctionsTest(git_test_utils.GitRepoReadOnlyTestBase,
                      self.repo.run(self.gc.diff, 'tag_C', 'tag_D').split('\n'))
 
   def testDormant(self):
-    self.assertFalse(self.repo.run(self.gc.is_dormant, 'master'))
-    self.repo.git('config', 'branch.master.dormant', 'true')
-    self.assertTrue(self.repo.run(self.gc.is_dormant, 'master'))
+    self.assertFalse(self.repo.run(self.gc.is_dormant, 'main'))
+    self.repo.git('config', 'branch.main.dormant', 'true')
+    self.assertTrue(self.repo.run(self.gc.is_dormant, 'main'))
 
   def testBlame(self):
     def get_porcelain_for_commit(commit_name, lines):
@@ -313,8 +313,8 @@ class GitReadOnlyFunctionsTest(git_test_utils.GitRepoReadOnlyTestBase,
   def testParseCommitrefs(self):
     ret = self.repo.run(
       self.gc.parse_commitrefs, *[
-        'master',
-        'master~3',
+        'main',
+        'main~3',
         self.repo['E']+'~',
         self.repo['D']+'^2',
         'tag_C^{}',
@@ -328,8 +328,8 @@ class GitReadOnlyFunctionsTest(git_test_utils.GitRepoReadOnlyTestBase,
       self.repo['C'],
     ]))
 
-    with self.assertRaisesRegexp(Exception, r"one of \('master', 'bananas'\)"):
-      self.repo.run(self.gc.parse_commitrefs, 'master', 'bananas')
+    with self.assertRaisesRegexp(Exception, r"one of \('main', 'bananas'\)"):
+      self.repo.run(self.gc.parse_commitrefs, 'main', 'bananas')
 
   def testRepoRoot(self):
     def cd_and_repo_root(path):
@@ -346,7 +346,7 @@ class GitReadOnlyFunctionsTest(git_test_utils.GitRepoReadOnlyTestBase,
                      {'tag_'+l for l in 'ABCDE'})
 
   def testTree(self):
-    tree = self.repo.run(self.gc.tree, 'master:some/files')
+    tree = self.repo.run(self.gc.tree, 'main:some/files')
     file1 = self.COMMIT_A['some/files/file1']['data']
     file2 = self.COMMIT_D['some/files/file2']['data']
     file3 = self.COMMIT_A['some/files/file3']['data']
@@ -360,16 +360,16 @@ class GitReadOnlyFunctionsTest(git_test_utils.GitRepoReadOnlyTestBase,
         tree['file3'],
         ('100644', 'blob', git_test_utils.git_hash_data(file3)))
 
-    tree = self.repo.run(self.gc.tree, 'master:some')
+    tree = self.repo.run(self.gc.tree, 'main:some')
     self.assertEquals(len(tree), 2)
     # Don't check the tree hash because we're lazy :)
     self.assertEquals(tree['files'][:2], ('040000', 'tree'))
 
-    tree = self.repo.run(self.gc.tree, 'master:wat')
+    tree = self.repo.run(self.gc.tree, 'main:wat')
     self.assertEqual(tree, None)
 
   def testTreeRecursive(self):
-    tree = self.repo.run(self.gc.tree, 'master:some', recurse=True)
+    tree = self.repo.run(self.gc.tree, 'main:some', recurse=True)
     file1 = self.COMMIT_A['some/files/file1']['data']
     file2 = self.COMMIT_D['some/files/file2']['data']
     file3 = self.COMMIT_A['some/files/file3']['data']
@@ -438,7 +438,7 @@ class GitMutableFunctionsTest(git_test_utils.GitRepoReadWriteTestBase,
     self.assertEquals('cat', self.repo.run(self.gc.get_config, 'dude.bob',
                                            'cat'))
 
-    self.assertEquals('origin/master', self.repo.run(self.gc.root))
+    self.assertEquals('origin/main', self.repo.run(self.gc.root))
 
     self.repo.git('config', 'depot-tools.upstream', 'catfood')
 
@@ -447,10 +447,10 @@ class GitMutableFunctionsTest(git_test_utils.GitRepoReadWriteTestBase,
   def testUpstream(self):
     self.repo.git('commit', '--allow-empty', '-am', 'foooooo')
     self.assertEquals(self.repo.run(self.gc.upstream, 'bobly'), None)
-    self.assertEquals(self.repo.run(self.gc.upstream, 'master'), None)
-    self.repo.git('checkout', '-tb', 'happybranch', 'master')
+    self.assertEquals(self.repo.run(self.gc.upstream, 'main'), None)
+    self.repo.git('checkout', '-tb', 'happybranch', 'main')
     self.assertEquals(self.repo.run(self.gc.upstream, 'happybranch'),
-                      'master')
+                      'main')
 
   def testNormalizedVersion(self):
     self.assertTrue(all(
@@ -458,11 +458,11 @@ class GitMutableFunctionsTest(git_test_utils.GitRepoReadWriteTestBase,
 
   def testGetBranchesInfo(self):
     self.repo.git('commit', '--allow-empty', '-am', 'foooooo')
-    self.repo.git('checkout', '-tb', 'happybranch', 'master')
+    self.repo.git('checkout', '-tb', 'happybranch', 'main')
     self.repo.git('commit', '--allow-empty', '-am', 'foooooo')
     self.repo.git('checkout', '-tb', 'child', 'happybranch')
 
-    self.repo.git('checkout', '-tb', 'to_delete', 'master')
+    self.repo.git('checkout', '-tb', 'to_delete', 'main')
     self.repo.git('checkout', '-tb', 'parent_gone', 'to_delete')
     self.repo.git('branch', '-D', 'to_delete')
 
@@ -474,7 +474,7 @@ class GitMutableFunctionsTest(git_test_utils.GitRepoReadWriteTestBase,
     expected = {
         'happybranch': (
             self.repo.run(self.gc.hash_one, 'happybranch', short=True),
-            'master',
+            'main',
             1 if supports_track else None,
             None
         ),
@@ -484,8 +484,8 @@ class GitMutableFunctionsTest(git_test_utils.GitRepoReadWriteTestBase,
             None,
             None
         ),
-        'master': (
-            self.repo.run(self.gc.hash_one, 'master', short=True),
+        'main': (
+            self.repo.run(self.gc.hash_one, 'main', short=True),
             '',
             None,
             None
@@ -619,7 +619,7 @@ class GitMutableStructuredTest(git_test_utils.GitRepoReadWriteTestBase,
   def testGetBranchTree(self):
     skipped, tree = self.repo.run(self.gc.get_branch_tree)
     # This check fails with git 2.4 (see crbug.com/487172)
-    self.assertEqual(skipped, {'master', 'root_X', 'branch_DOG', 'root_CAT'})
+    self.assertEqual(skipped, {'main', 'root_X', 'branch_DOG', 'root_CAT'})
     self.assertEqual(tree, {
       'branch_G': 'root_A',
       'root_A': 'root_X',

--- a/tests/git_footers_test.py
+++ b/tests/git_footers_test.py
@@ -17,11 +17,11 @@ class GitFootersTest(TestCase):
   _message = """
 This is my commit message. There are many like it, but this one is mine.
 
-My commit message is my best friend. It is my life. I must master it.
+My commit message is my best friend. It is my life. I must main it.
 
 """
 
-  _position = 'refs/heads/master@{#292272}'
+  _position = 'refs/heads/main@{#292272}'
 
   _position_footer = 'Cr-Commit-Position: %s\n' % _position
 
@@ -66,7 +66,7 @@ My commit message is my best friend. It is my life. I must master it.
         { 'Git-Svn-Id': [ self._git_svn_id ] })
     self.assertEqual(
         git_footers.get_position(footers),
-        ('refs/heads/master', '290386'))
+        ('refs/heads/main', '290386'))
 
   def testBranchHeuristic(self):
     footers = git_footers.parse_footers(self._message +

--- a/tests/git_rebase_update_test.py
+++ b/tests/git_rebase_update_test.py
@@ -51,18 +51,18 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
             J L
     """, self.getRepoContent)
     self.origin = origin_schema.reify()
-    self.origin.git('checkout', 'master')
+    self.origin.git('checkout', 'main')
     self.origin.git('branch', '-d', *['branch_'+l for l in 'KLG'])
 
     self.repo.git('remote', 'add', 'origin', self.origin.repo_path)
     self.repo.git('config', '--add', 'remote.origin.fetch',
                   '+refs/tags/*:refs/tags/*')
-    self.repo.git('update-ref', 'refs/remotes/origin/master', 'tag_E')
+    self.repo.git('update-ref', 'refs/remotes/origin/main', 'tag_E')
     self.repo.git('branch', '--set-upstream-to', 'branch_G', 'branch_K')
     self.repo.git('branch', '--set-upstream-to', 'branch_K', 'branch_L')
-    self.repo.git('branch', '--set-upstream-to', 'origin/master', 'branch_G')
+    self.repo.git('branch', '--set-upstream-to', 'origin/main', 'branch_G')
 
-    self.repo.to_schema_refs += ['origin/master']
+    self.repo.to_schema_refs += ['origin/main']
 
   def tearDown(self):
     self.origin.nuke()
@@ -73,7 +73,7 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
 
     self.repo.run(self.nb.main, ['foobar'])
     self.assertEqual(self.repo.git('rev-parse', 'HEAD').stdout,
-                     self.repo.git('rev-parse', 'origin/master').stdout)
+                     self.repo.git('rev-parse', 'origin/main').stdout)
 
     with self.repo.open('foobar', 'w') as f:
       f.write('this is the foobar file')
@@ -106,7 +106,7 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
     self.repo.git_commit('old_file')
     self.repo.git('config', 'branch.old_branch.dormant', 'true')
 
-    self.repo.git('checkout', 'origin/master')
+    self.repo.git('checkout', 'origin/main')
 
     self.assertSchema("""
     A B H I J K sub_K
@@ -141,7 +141,7 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
     self.assertIn('Deleted branch empty_branch2', output)
     self.assertIn('Deleted branch int1_foobar', output)
     self.assertIn('Deleted branch int2_foobar', output)
-    self.assertIn('Reparented branch_K to track origin/master', output)
+    self.assertIn('Reparented branch_K to track origin/main', output)
     self.assertIn('Reparented sub_foobar to track foobar', output)
 
     self.assertSchema("""
@@ -162,14 +162,14 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
 
     self.assertEqual(self.repo.git('status', '--porcelain').stdout, '?? bob\n')
 
-    self.repo.git('checkout', 'origin/master')
+    self.repo.git('checkout', 'origin/main')
     _, err = self.repo.capture_stdio(self.rp.main, [])
     self.assertIn('Must specify new parent somehow', err)
     _, err = self.repo.capture_stdio(self.rp.main, ['foobar'])
     self.assertIn('Must be on the branch', err)
 
     self.repo.git('checkout', 'branch_K')
-    _, err = self.repo.capture_stdio(self.rp.main, ['origin/master'])
+    _, err = self.repo.capture_stdio(self.rp.main, ['origin/main'])
     self.assertIn('Cannot reparent a branch to its existing parent', err)
     output, _ = self.repo.capture_stdio(self.rp.main, ['foobar'])
     self.assertIn('Rebasing: branch_K', output)
@@ -202,7 +202,7 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
     self.assertEqual(self.repo.git('status', '--porcelain').stdout, '?? bob\n')
 
     branches = self.repo.run(set, self.gc.branches())
-    self.assertEqual(branches, {'branch_K', 'master', 'sub_K', 'root_A',
+    self.assertEqual(branches, {'branch_K', 'main', 'sub_K', 'root_A',
                                 'branch_L', 'old_branch', 'foobar',
                                 'sub_foobar'})
 
@@ -210,18 +210,18 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
     self.repo.run(self.mv.main, ['special_K'])
 
     branches = self.repo.run(set, self.gc.branches())
-    self.assertEqual(branches, {'special_K', 'master', 'sub_K', 'root_A',
+    self.assertEqual(branches, {'special_K', 'main', 'sub_K', 'root_A',
                                 'branch_L', 'old_branch', 'foobar',
                                 'sub_foobar'})
 
-    self.repo.git('checkout', 'origin/master')
+    self.repo.git('checkout', 'origin/main')
     _, err = self.repo.capture_stdio(self.mv.main, ['special_K', 'cool branch'])
     self.assertIn('fatal: \'cool branch\' is not a valid branch name.', err)
 
     self.repo.run(self.mv.main, ['special_K', 'cool_branch'])
     branches = self.repo.run(set, self.gc.branches())
     # This check fails with git 2.4 (see crbug.com/487172)
-    self.assertEqual(branches, {'cool_branch', 'master', 'sub_K', 'root_A',
+    self.assertEqual(branches, {'cool_branch', 'main', 'sub_K', 'root_A',
                                 'branch_L', 'old_branch', 'foobar',
                                 'sub_foobar'})
 
@@ -231,7 +231,7 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
 
   def testRebaseConflicts(self):
     # Pretend that branch_L landed
-    self.origin.git('checkout', 'master')
+    self.origin.git('checkout', 'main')
     with self.origin.open('L', 'w') as f:
       f.write('L')
     self.origin.git('add', 'L')
@@ -273,11 +273,11 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
     self.assertIn('Deleted branch branch_G', output)
     self.assertIn('Deleted branch branch_L', output)
     self.assertIn('\'branch_G\' was merged', output)
-    self.assertIn('checking out \'origin/master\'', output)
+    self.assertIn('checking out \'origin/main\'', output)
 
   def testRebaseConflictsKeepGoing(self):
     # Pretend that branch_L landed
-    self.origin.git('checkout', 'master')
+    self.origin.git('checkout', 'main')
     with self.origin.open('L', 'w') as f:
       f.write('L')
     self.origin.git('add', 'L')
@@ -380,7 +380,7 @@ class GitRebaseUpdateTest(git_test_utils.GitRepoReadWriteTestBase):
     """)
 
     output, _ = self.repo.capture_stdio(self.rp.main, ['--root'])
-    self.assertIn('to track origin/master (was lkgr [tag])', output)
+    self.assertIn('to track origin/main (was lkgr [tag])', output)
 
     self.assertSchema("""
     A B C D E F G M N O foobar1 foobar2

--- a/tests/patch_test.py
+++ b/tests/patch_test.py
@@ -74,7 +74,7 @@ class PatchTest(unittest.TestCase):
     self._check_patch(p, 'chrome/file.cc', RAW.PATCH, nb_hunks=1)
 
   def testDifferent(self):
-    name = 'master/unittests/data/processes-summary.dat'
+    name = 'main/unittests/data/processes-summary.dat'
     p = patch.FilePatchDiff(name, RAW.DIFFERENT, [])
     self._check_patch(p, name, RAW.DIFFERENT, nb_hunks=1)
 

--- a/tests/presubmit_unittest.py
+++ b/tests/presubmit_unittest.py
@@ -49,21 +49,21 @@ def CheckChangeOnUpload(input_api, output_api):
   else:
     return ()
 """
-  presubmit_tryslave = """
-def GetPreferredTrySlaves():
+  presubmit_trysubordinate = """
+def GetPreferredTrySubordinates():
   return %s
 """
 
-  presubmit_tryslave_project = """
-def GetPreferredTrySlaves(project):
+  presubmit_trysubordinate_project = """
+def GetPreferredTrySubordinates(project):
   if project == %s:
     return %s
   else:
     return %s
 """
 
-  presubmit_trymaster = """
-def GetPreferredTryMasters(project, change):
+  presubmit_trymain = """
+def GetPreferredTryMains(project, change):
   return %s
 """
 
@@ -170,9 +170,9 @@ class PresubmitUnittest(PresubmitTestsBase):
   def testMembersChanged(self):
     self.mox.ReplayAll()
     members = [
-      'AffectedFile', 'Change', 'DoGetTrySlaves',
+      'AffectedFile', 'Change', 'DoGetTrySubordinates',
       'DoPostUploadExecuter', 'DoPresubmitChecks', 'GetPostUploadExecuter',
-      'GetTrySlavesExecuter', 'GitAffectedFile', 'CallCommand', 'CommandData',
+      'GetTrySubordinatesExecuter', 'GitAffectedFile', 'CallCommand', 'CommandData',
       'GitChange', 'InputApi', 'ListRelevantPresubmitFiles', 'main',
       'NonexistantCannedCheckFilter', 'OutputApi', 'ParseFiles',
       'PresubmitFailure', 'PresubmitExecuter', 'PresubmitOutput', 'ScanSubDirs',
@@ -182,8 +182,8 @@ class PresubmitUnittest(PresubmitTestsBase):
       'marshal', 'normpath', 'optparse', 'os', 'owners', 'pickle',
       'presubmit_canned_checks', 'random', 're', 'rietveld', 'scm',
       'subprocess', 'sys', 'tempfile', 'time', 'traceback', 'types', 'unittest',
-      'urllib2', 'warn', 'multiprocessing', 'DoGetTryMasters',
-      'GetTryMastersExecuter', 'itertools', 'urlparse', 'gerrit_util',
+      'urllib2', 'warn', 'multiprocessing', 'DoGetTryMains',
+      'GetTryMainsExecuter', 'itertools', 'urlparse', 'gerrit_util',
       'GerritAccessor',
     ]
     # If this test fails, you should add the relevant test.
@@ -963,7 +963,7 @@ def CheckChangeOnCommit(input_api, output_api):
                        '\n'
                        'Presubmit checks passed.\n'))
 
-  def testGetTrySlavesExecuter(self):
+  def testGetTrySubordinatesExecuter(self):
     self.mox.ReplayAll()
     change = presubmit.Change(
         'foo',
@@ -973,7 +973,7 @@ def CheckChangeOnCommit(input_api, output_api):
         0,
         0,
         None)
-    executer = presubmit.GetTrySlavesExecuter()
+    executer = presubmit.GetTrySubordinatesExecuter()
     self.assertEqual([], executer.ExecPresubmitScript('', '', '', change))
     self.assertEqual([],
         executer.ExecPresubmitScript('def foo():\n  return\n', '', '', change))
@@ -989,7 +989,7 @@ def CheckChangeOnCommit(input_api, output_api):
         mixed_old_and_new, not_set):
       self.assertRaises(presubmit.PresubmitFailure,
                         executer.ExecPresubmitScript,
-                        self.presubmit_tryslave % result, '', '', change)
+                        self.presubmit_trysubordinate % result, '', '', change)
 
     # good results
     expected_result = ['1', '2', '3']
@@ -1001,9 +1001,9 @@ def CheckChangeOnCommit(input_api, output_api):
       self.assertEqual(
           result,
           executer.ExecPresubmitScript(
-              self.presubmit_tryslave % result, '', '', change))
+              self.presubmit_trysubordinate % result, '', '', change))
 
-  def testGetTrySlavesExecuterWithProject(self):
+  def testGetTrySubordinatesExecuterWithProject(self):
     self.mox.ReplayAll()
 
     change = presubmit.Change(
@@ -1015,10 +1015,10 @@ def CheckChangeOnCommit(input_api, output_api):
         0,
         None)
 
-    executer = presubmit.GetTrySlavesExecuter()
+    executer = presubmit.GetTrySubordinatesExecuter()
     expected_result1 = ['1', '2']
     expected_result2 = ['a', 'b', 'c']
-    script = self.presubmit_tryslave_project % (
+    script = self.presubmit_trysubordinate_project % (
         repr('foo'), repr(expected_result1), repr(expected_result2))
     self.assertEqual(
         expected_result1, executer.ExecPresubmitScript(script, '', 'foo',
@@ -1027,7 +1027,7 @@ def CheckChangeOnCommit(input_api, output_api):
         expected_result2, executer.ExecPresubmitScript(script, '', 'bar',
                                                        change))
 
-  def testDoGetTrySlaves(self):
+  def testDoGetTrySubordinates(self):
     join = presubmit.os.path.join
     filename = 'foo.cc'
     filename_linux = join('linux_only', 'penguin.cc')
@@ -1040,7 +1040,7 @@ def CheckChangeOnCommit(input_api, output_api):
     presubmit.os.listdir(self.fake_root_dir).AndReturn(['PRESUBMIT.py'])
     presubmit.os.path.isfile(root_presubmit).AndReturn(True)
     presubmit.gclient_utils.FileRead(root_presubmit, 'rU').AndReturn(
-        self.presubmit_tryslave % '["win"]')
+        self.presubmit_trysubordinate % '["win"]')
 
     presubmit.os.path.isfile(inherit_path).AndReturn(False)
     presubmit.os.listdir(self.fake_root_dir).AndReturn(['PRESUBMIT.py'])
@@ -1049,9 +1049,9 @@ def CheckChangeOnCommit(input_api, output_api):
         ['PRESUBMIT.py'])
     presubmit.os.path.isfile(linux_presubmit).AndReturn(True)
     presubmit.gclient_utils.FileRead(root_presubmit, 'rU').AndReturn(
-        self.presubmit_tryslave % '["win"]')
+        self.presubmit_trysubordinate % '["win"]')
     presubmit.gclient_utils.FileRead(linux_presubmit, 'rU').AndReturn(
-        self.presubmit_tryslave % '["linux"]')
+        self.presubmit_trysubordinate % '["linux"]')
     self.mox.ReplayAll()
 
     change = presubmit.Change(
@@ -1059,36 +1059,36 @@ def CheckChangeOnCommit(input_api, output_api):
 
     output = StringIO.StringIO()
     self.assertEqual(['win'],
-                     presubmit.DoGetTrySlaves(change, [filename],
+                     presubmit.DoGetTrySubordinates(change, [filename],
                                               self.fake_root_dir,
                                               None, None, False, output))
     output = StringIO.StringIO()
     self.assertEqual(['win', 'linux'],
-                     presubmit.DoGetTrySlaves(change,
+                     presubmit.DoGetTrySubordinates(change,
                                               [filename, filename_linux],
                                               self.fake_root_dir, None, None,
                                               False, output))
 
-  def testGetTrySlavesExecuter_ok(self):
+  def testGetTrySubordinatesExecuter_ok(self):
     script_text = (
-        'def GetPreferredTrySlaves():\n'
+        'def GetPreferredTrySubordinates():\n'
         '  return ["foo", "bar"]\n')
-    results = presubmit.GetTrySlavesExecuter.ExecPresubmitScript(
+    results = presubmit.GetTrySubordinatesExecuter.ExecPresubmitScript(
         script_text, 'path', 'project', None)
     self.assertEquals(['foo', 'bar'], results)
 
-  def testGetTrySlavesExecuter_comma(self):
+  def testGetTrySubordinatesExecuter_comma(self):
     script_text = (
-        'def GetPreferredTrySlaves():\n'
+        'def GetPreferredTrySubordinates():\n'
         '  return ["foo,bar"]\n')
     try:
-      presubmit.GetTrySlavesExecuter.ExecPresubmitScript(
+      presubmit.GetTrySubordinatesExecuter.ExecPresubmitScript(
           script_text, 'path', 'project', None)
       self.fail()
     except presubmit.PresubmitFailure:
       pass
 
-  def testGetTryMastersExecuter(self):
+  def testGetTryMainsExecuter(self):
     self.mox.ReplayAll()
     change = presubmit.Change(
         'foo',
@@ -1098,7 +1098,7 @@ def CheckChangeOnCommit(input_api, output_api):
         0,
         0,
         None)
-    executer = presubmit.GetTryMastersExecuter()
+    executer = presubmit.GetTryMainsExecuter()
     self.assertEqual({}, executer.ExecPresubmitScript('', '', '', change))
     self.assertEqual({},
         executer.ExecPresubmitScript('def foo():\n  return\n', '', '', change))
@@ -1114,10 +1114,10 @@ def CheckChangeOnCommit(input_api, output_api):
       self.assertEqual(
           result,
           executer.ExecPresubmitScript(
-              self.presubmit_trymaster % result, '', '', change))
+              self.presubmit_trymain % result, '', '', change))
 
-  def testMergeMasters(self):
-    merge = presubmit._MergeMasters
+  def testMergeMains(self):
+    merge = presubmit._MergeMains
     self.assertEqual({}, merge({}, {}))
     self.assertEqual({'m1': {}}, merge({}, {'m1': {}}))
     self.assertEqual({'m1': {}}, merge({'m1': {}}, {}))
@@ -1139,10 +1139,10 @@ def CheckChangeOnCommit(input_api, output_api):
     for permutation in itertools.permutations(parts):
       self.assertEqual(expected, reduce(merge, permutation, {}))
 
-  def testDoGetTryMasters(self):
-    root_text = (self.presubmit_trymaster
+  def testDoGetTryMains(self):
+    root_text = (self.presubmit_trymain
         % '{"t1.cr": {"win": set(["defaulttests"])}}')
-    linux_text = (self.presubmit_trymaster
+    linux_text = (self.presubmit_trymain
         % ('{"t1.cr": {"linux1": set(["t1"])},'
            ' "t2.cr": {"linux2": set(["defaulttests"])}}'))
 
@@ -1175,7 +1175,7 @@ def CheckChangeOnCommit(input_api, output_api):
 
     output = StringIO.StringIO()
     self.assertEqual({'t1.cr': {'win': ['defaulttests']}},
-                     presubmit.DoGetTryMasters(change, [filename],
+                     presubmit.DoGetTryMains(change, [filename],
                                                self.fake_root_dir,
                                                None, None, False, output))
     output = StringIO.StringIO()
@@ -1184,7 +1184,7 @@ def CheckChangeOnCommit(input_api, output_api):
       't2.cr': {'linux2': ['defaulttests']},
     }
     self.assertEqual(expected,
-                     presubmit.DoGetTryMasters(change,
+                     presubmit.DoGetTryMains(change,
                                                [filename, filename_linux],
                                                self.fake_root_dir, None, None,
                                                False, output))

--- a/third_party/boto/pyami/bootstrap.py
+++ b/third_party/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/third_party/cq_client/cq.pb.go
+++ b/third_party/cq_client/cq.pb.go
@@ -456,9 +456,9 @@ func (m *Verifiers_TryJobVerifier_Builder) GetExperimentPercentage() float32 {
 }
 
 type Verifiers_TryJobVerifier_Bucket struct {
-	// Name of the bucket. This is typically the same as a master name without
-	// the 'master.' prefix, e.g. 'chromium.linux' or 'tryserver.webrtc'. CQ
-	// will automatically add 'master.' prefix if not there.
+	// Name of the bucket. This is typically the same as a main name without
+	// the 'main.' prefix, e.g. 'chromium.linux' or 'tryserver.webrtc'. CQ
+	// will automatically add 'main.' prefix if not there.
 	Name *string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
 	// Builders on which tryjobs should be triggered.
 	Builders         []*Verifiers_TryJobVerifier_Builder `protobuf:"bytes,2,rep,name=builders" json:"builders,omitempty"`

--- a/third_party/logilab/common/__pkginfo__.py
+++ b/third_party/logilab/common/__pkginfo__.py
@@ -23,7 +23,7 @@ import os
 distname = 'logilab-common'
 modname = 'common'
 subpackage_of = 'logilab'
-subpackage_master = True
+subpackage_main = True
 
 numversion = (0, 63, 2)
 version = '.'.join([str(num) for num in numversion])

--- a/third_party/pylint/lint.py
+++ b/third_party/pylint/lint.py
@@ -239,7 +239,7 @@ class PyLinter(configuration.OptionsManagerMixIn,
 
     __implements__ = (interfaces.ITokenChecker, )
 
-    name = 'master'
+    name = 'main'
     priority = 0
     level = 0
     msgs = MSGS

--- a/third_party/pylint/utils.py
+++ b/third_party/pylint/utils.py
@@ -414,7 +414,7 @@ class MessagesHandlerMixIn(object):
 
         by_checker = {}
         for checker in self.get_checkers():
-            if checker.name == 'master':
+            if checker.name == 'main':
                 if checker.options:
                     for section, options in checker.options_by_section():
                         if section is None:


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.